### PR TITLE
Query server only once per update period

### DIFF
--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -33,7 +33,7 @@ from homeassistant.helpers import config_validation as cv, entity_registry as er
 try:
     from homeassistant.helpers.device_registry import DeviceInfo
 except ImportError:
-    from homeassistant.helpers.entity import DeviceInfo
+    from homeassistant.helpers.entity import DeviceInfo  # type: ignore[attr-defined]
 
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import track_time_interval


### PR DESCRIPTION
The get_all_people method depended on the caching of the _get_data method, but that caching was improperly implemented. I.e., it only cached when one Google account was in use. If more than one account was used, the caching did not take "self" into account, so would get immediately overwritten. Also, a time-based cache is really inappropriate given the way HA uses the package.

This change adds a new method that retrieves and parses the data and checks for errors, and then saves it for an overridden _get_data method to return. The user then calls the new method each update period before calling get_shared_people, get_authenticated_person or get_all_people.

The change also overrides get_all_people to avoid the unnecessary use of the filter function.

Fixes #10 