### PR TITLE
Do not record entity_picture attribute in database

### DIFF
--- a/custom_components/google_maps/const.py
+++ b/custom_components/google_maps/const.py
@@ -1,6 +1,8 @@
 """Constants for Google Maps Integration."""
 from datetime import timedelta
 
+from homeassistant.const import ATTR_ENTITY_PICTURE
+
 DOMAIN = "google_maps"
 ATTRIBUTION = "Data from Google Maps"
 NAME_PREFIX = "Google Maps"
@@ -19,3 +21,5 @@ ATTR_NICKNAME = "nickname"
 CONF_COOKIES_FILE = "cookies_file"
 CONF_CREATE_ACCT_ENTITY = "create_acct_entity"
 CONF_MAX_GPS_ACCURACY = "max_gps_accuracy"
+
+DT_NO_RECORD_ATTRS = frozenset({ATTR_ADDRESS, ATTR_ENTITY_PICTURE, ATTR_NICKNAME})

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -56,6 +56,7 @@ from .const import (
     CONF_MAX_GPS_ACCURACY,
     DEF_SCAN_INTERVAL,
     DOMAIN,
+    DT_NO_RECORD_ATTRS,
     NAME_PREFIX,
 )
 from .coordinator import GMDataUpdateCoordinator, GMIntegData
@@ -222,7 +223,7 @@ class GoogleMapsDeviceTracker(
 ):
     """Google Maps Device Tracker."""
 
-    _unrecorded_attributes = frozenset({ATTR_ADDRESS, ATTR_NICKNAME})
+    _unrecorded_attributes = DT_NO_RECORD_ATTRS
     _attr_attribution = ATTRIBUTION
     _attr_translation_key = "tracker"
 


### PR DESCRIPTION
Attributes address & nickname were already not recorded in the database. entity_picture has a relatively large value and will almost never change, so add it to the list of attributes to not record.