### PR TITLE
Move unavailable status to separate binary sensor

### DIFF
--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -16,7 +16,7 @@ from .coordinator import GMDataUpdateCoordinator, GMIntegData
 from .helpers import ConfigID, ConfigUniqueIDs, cookies_file_path
 
 _LOGGER = logging.getLogger(__name__)
-_PLATFORMS = [Platform.DEVICE_TRACKER]
+_PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
 
 
 async def entry_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -7,10 +7,9 @@ from typing import cast
 
 from homeassistant.components.device_tracker import DOMAIN as DT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_USERNAME, EVENT_HOMEASSISTANT_STOP, Platform
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.const import CONF_USERNAME, Platform
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
-from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_COOKIES_FILE, CONF_CREATE_ACCT_ENTITY, DOMAIN, NAME_PREFIX
 from .coordinator import GMDataUpdateCoordinator, GMIntegData
@@ -18,29 +17,6 @@ from .helpers import ConfigID, ConfigUniqueIDs, cookies_file_path
 
 _LOGGER = logging.getLogger(__name__)
 _PLATFORMS = [Platform.DEVICE_TRACKER]
-
-
-async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
-    """Set up integration."""
-    hass.data[DOMAIN] = GMIntegData(ConfigUniqueIDs(hass))
-    ent_reg = er.async_get(hass)
-
-    async def device_work_around(_: Event) -> None:
-        """Work around for device tracker component deleting devices.
-
-        The device tracker component level code, at startup, deletes devices that are
-        associated only with device_tracker entities. Not only that, it will delete
-        those device_tracker entities from the entity registry as well. So, when HA
-        shuts down, remove references to devices from our device_tracker entity registry
-        entries. They'll get set back up automatically the next time our config is
-        loaded (i.e., setup.)
-        """
-        for c_entry in hass.config_entries.async_entries(DOMAIN):
-            for r_entry in er.async_entries_for_config_entry(ent_reg, c_entry.entry_id):
-                ent_reg.async_update_entity(r_entry.entity_id, device_id=None)
-
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, device_work_around)
-    return True
 
 
 async def entry_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -79,7 +55,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data[CONF_USERNAME]
     create_acct_entity = entry.options[CONF_CREATE_ACCT_ENTITY]
 
-    gmi_data = cast(GMIntegData, hass.data.get(DOMAIN))
+    if not (gmi_data := cast(GMIntegData | None, hass.data.get(DOMAIN))):
+        hass.data[DOMAIN] = gmi_data = GMIntegData(ConfigUniqueIDs(hass))
 
     # For "account person", unique ID is username (which is also returned in person.id.)
     ent_reg = er.async_get(hass)

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -7,9 +7,10 @@ from typing import cast
 
 from homeassistant.components.device_tracker import DOMAIN as DT_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_USERNAME, EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_COOKIES_FILE, CONF_CREATE_ACCT_ENTITY, DOMAIN, NAME_PREFIX
 from .coordinator import GMDataUpdateCoordinator, GMIntegData
@@ -17,6 +18,29 @@ from .helpers import ConfigID, ConfigUniqueIDs, cookies_file_path
 
 _LOGGER = logging.getLogger(__name__)
 _PLATFORMS = [Platform.DEVICE_TRACKER]
+
+
+async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
+    """Set up integration."""
+    hass.data[DOMAIN] = GMIntegData(ConfigUniqueIDs(hass))
+    ent_reg = er.async_get(hass)
+
+    async def device_work_around(_: Event) -> None:
+        """Work around for device tracker component deleting devices.
+
+        The device tracker component level code, at startup, deletes devices that are
+        associated only with device_tracker entities. Not only that, it will delete
+        those device_tracker entities from the entity registry as well. So, when HA
+        shuts down, remove references to devices from our device_tracker entity registry
+        entries. They'll get set back up automatically the next time our config is
+        loaded (i.e., setup.)
+        """
+        for c_entry in hass.config_entries.async_entries(DOMAIN):
+            for r_entry in er.async_entries_for_config_entry(ent_reg, c_entry.entry_id):
+                ent_reg.async_update_entity(r_entry.entity_id, device_id=None)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, device_work_around)
+    return True
 
 
 async def entry_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -55,8 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     username = entry.data[CONF_USERNAME]
     create_acct_entity = entry.options[CONF_CREATE_ACCT_ENTITY]
 
-    if not (gmi_data := cast(GMIntegData | None, hass.data.get(DOMAIN))):
-        hass.data[DOMAIN] = gmi_data = GMIntegData(ConfigUniqueIDs(hass))
+    gmi_data = cast(GMIntegData, hass.data.get(DOMAIN))
 
     # For "account person", unique ID is username (which is also returned in person.id.)
     ent_reg = er.async_get(hass)

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -78,6 +78,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             dev_reg.async_remove_device(device.id)
         unique_ids.release(cid, username)
 
+    # The code here: https://github.com/home-assistant/core/blob/0fa395556db8ba97ec95d103c9a232f7ab964432/homeassistant/components/device_tracker/config_entry.py#L54-L74
+    # deletes any devices that are associated with any entities in the device_tracker
+    # domain that are not also associated with any entities in any other domains.
+    # This was apparently to fix issues from some much older HA version. However,
+    # although we generally just recreate those devices, there is a race condition that
+    # can happen where the above referenced code will also remove the entity from the
+    # entity registry. That can cause the entity to disappear from the system, even
+    # though our device_tracker code is still updating it.
+    # See issue: https://github.com/pnbruckner/ha-google-maps/issues/25
+    # To work around that code (that should have been removed a long time ago), we'll
+    # temporarily disassociate our entities from their devices. This will prevent the
+    # problem code from removing our entities from the entity registry. When our
+    # entities are added to hass, the devices will be recreated (if necessary) and the
+    # entities will be reassociated with them.
+    for uid in unique_ids.owned(cid):
+        if entity_id := ent_reg.async_get_entity_id(DT_DOMAIN, DOMAIN, uid):
+            ent_reg.async_update_entity(entity_id, device_id=None)
+
     coordinator = GMDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     gmi_data.coordinators[cid] = coordinator

--- a/custom_components/google_maps/binary_sensor.py
+++ b/custom_components/google_maps/binary_sensor.py
@@ -1,0 +1,56 @@
+"""Google Maps binary sensor."""
+from __future__ import annotations
+
+from typing import cast
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import ATTRIBUTION, DOMAIN, NAME_PREFIX
+from .coordinator import GMDataUpdateCoordinator, GMIntegData
+from .helpers import ConfigID
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the binary sensor platform."""
+    cid = cast(ConfigID, entry.entry_id)
+    gmi_data = cast(GMIntegData, hass.data[DOMAIN])
+    coordinator = gmi_data.coordinators[cid]
+
+    async_add_entities([GoogleMapsBinarySensor(coordinator)])
+
+
+class GoogleMapsBinarySensor(
+    CoordinatorEntity[GMDataUpdateCoordinator], BinarySensorEntity
+):
+    """Google Maps Binary Sensor."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+
+    def __init__(self, coordinator: GMDataUpdateCoordinator) -> None:
+        """Initialize Google Maps Binary Sensor."""
+        super().__init__(coordinator)
+        entry = coordinator.config_entry
+        self._attr_unique_id = entry.entry_id
+        self._attr_name = f"{NAME_PREFIX} {entry.title} online"
+        self._attr_is_on = super().available
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return True
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self._attr_is_on = super().available
+        super()._handle_coordinator_update()

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -295,6 +295,11 @@ class GoogleMapsDeviceTracker(
         return self._misc.entity_picture
 
     @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return True
+
+    @property
     def force_update(self) -> bool:
         """Return True if state updates should be forced."""
         return False

--- a/custom_components/google_maps/gm_loc_sharing.py
+++ b/custom_components/google_maps/gm_loc_sharing.py
@@ -198,7 +198,7 @@ class GMLocSharing:
         expirations: list[int] = []
         for name in _VALID_COOKIE_NAMES:
             if (data := cookie_data.get(name)) and (expiration := data[0]):
-                expirations.append(expiration)
+                expirations.append(expiration)  # noqa: PERF401
         if not expirations:
             return None
         return datetime.fromtimestamp(min(expirations)).astimezone()

--- a/custom_components/google_maps/helpers.py
+++ b/custom_components/google_maps/helpers.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, NewType, Self, cast
 
+from homeassistant.components.device_tracker import DOMAIN as DT_DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.restore_state import ExtraStoredData
@@ -185,6 +186,7 @@ class ConfigUniqueIDs:
             cfg_uids = {
                 cast(UniqueID, ent.unique_id)
                 for ent in er.async_entries_for_config_entry(ent_reg, cid)
+                if ent.domain == DT_DOMAIN
             }
             self._all_uids.update(cfg_uids)
             self._cfg_uids[cid] = cfg_uids

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.2b2/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.2b3/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
   "requirements": ["locationsharinglib==5.0.1"],
-  "version": "1.3.2b2"
+  "version": "1.3.2b3"
 }

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -3,11 +3,11 @@
   "name": "Google Maps",
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
-  "dependencies": ["file_upload"],
+  "dependencies": ["device_tracker", "file_upload"],
   "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.1/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
-  "requirements": [],
+  "requirements": ["locationsharinglib==5.0.1"],
   "version": "1.3.1"
 }

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["device_tracker", "file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.1/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.2b0/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
   "requirements": ["locationsharinglib==5.0.1"],
-  "version": "1.3.1"
+  "version": "1.3.2b0"
 }

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -3,7 +3,7 @@
   "name": "Google Maps",
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
-  "dependencies": ["device_tracker", "file_upload"],
+  "dependencies": ["file_upload"],
   "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.2b1/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["device_tracker", "file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.2b0/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.2b1/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
   "requirements": ["locationsharinglib==5.0.1"],
-  "version": "1.3.2b0"
+  "version": "1.3.2b1"
 }

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.2b1/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.2b2/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
   "requirements": ["locationsharinglib==5.0.1"],
-  "version": "1.3.2b1"
+  "version": "1.3.2b2"
 }


### PR DESCRIPTION
Tracker entities should not become unavailable just because server temporarily doesn't respond. The entity's state is just the last known good sample point, regardless of how long ago it happened or was obtained. The last_seen attribute will always indicate how "stale" the sample point is, regardless of the reason.

But so that systems can respond appropriately if/when the server becomes unresponsive, add a binary sensor that indicates the status of communications with the server. This effectively moves the communications status to an "out of band" sensor, which is the way it should be.

Fix legacy tracker support by adding locationsharinglib back into the manifest requirements.

Lastly, due to some code in the device tracker component that was supposed to be removed a long time ago but wasn't (See [Core PR #114668](https://github.com/home-assistant/core/pull/114668)), and a bug in the entity registry code (see [Core PR #113623](https://github.com/home-assistant/core/pull/113623)), a race condition exists that can cause the entities this integration creates to not appear after a restart. This PR also adds code to work around that problem by deleting the devices at shutdown. They will automatically get recreated at startup.

Fixes: #25 