### PR TITLE
Use UTC datetimes internally & make last_seen attr HA's local tz

### DIFF
--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -34,6 +34,8 @@ async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
     async def device_work_around(_: Event) -> None:
         """Work around for device tracker component deleting devices.
 
+        Applies to HA versions prior to 2024.5:
+
         The device tracker component level code, at startup, deletes devices that are
         associated only with device_tracker entities. Not only that, it will delete
         those device_tracker entities from the entity registry as well. So, when HA

--- a/custom_components/google_maps/gm_loc_sharing.py
+++ b/custom_components/google_maps/gm_loc_sharing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import cached_property
 from http.cookiejar import MozillaCookieJar
 import json
@@ -86,7 +86,7 @@ class GMPerson:
     address: str
     country_code: str
     gps_accuracy: int
-    last_seen: datetime
+    last_seen: float
     latitude: float
     longitude: float
 
@@ -98,9 +98,7 @@ class GMPerson:
 
     def __post_init__(self) -> None:
         """Post initialization."""
-        self.last_seen = datetime.fromtimestamp(
-            int(self.last_seen) / 1000  # type: ignore[call-overload]
-        ).astimezone()
+        self.last_seen = int(self.last_seen) / 1000
 
     @classmethod
     def shared_from_data(cls, data: Sequence[Any]) -> Self | None:
@@ -184,7 +182,7 @@ class GMLocSharing:
 
     @property
     def _cookie_data(self) -> CookieData:
-        """Return pertient data for current cookies."""
+        """Return pertinent data for current cookies."""
         return {cookie.name: (cookie.expires, cookie.value) for cookie in self._cookies}
 
     @property
@@ -194,7 +192,7 @@ class GMLocSharing:
 
     @property
     def cookies_expiration(self) -> datetime | None:
-        """Return expiration of 'important' cookies."""
+        """Return expiration of 'important' cookies in UTC."""
         cookie_data = self._cookie_data
         expirations: list[int] = []
         for name in _VALID_COOKIE_NAMES:
@@ -202,7 +200,7 @@ class GMLocSharing:
                 expirations.append(expiration)  # noqa: PERF401
         if not expirations:
             return None
-        return datetime.fromtimestamp(min(expirations)).astimezone()
+        return datetime.fromtimestamp(min(expirations), UTC)
 
     def close(self) -> None:
         """Close API."""

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.4/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.3.5b0/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
   "requirements": ["locationsharinglib==5.0.1"],
-  "version": "1.3.4"
+  "version": "1.3.5b0"
 }


### PR DESCRIPTION
Python datetime object comparisons and math don't work as expected when the objects are aware and have the same tzinfo attribute. Basically, the fold attribute is ignored in this case, which can lead to wrong results.

Avoid this problem by using aware times in UTC internally. Only use local time zone for user visible attributes.

Also, use HA's local time zone instead of the OS's time zone.