### PR TITLE
Drop support for HA versions before 2024.12.0

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,7 @@ jobs:
     name: With hassfest
     steps:
     - name: 📥 Checkout the repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: 🏃 Hassfest validation
       uses: "home-assistant/actions/hassfest@master"

--- a/README.md
+++ b/README.md
@@ -137,23 +137,32 @@ Find or search for "Google Maps", click on it, then follow the prompts.
 > It will take you to a sub-list of all Google related integrations.
 > There will also be a "Google Maps" item in that list, but it is for the built-in integration, not this custom one.
 
-<details>
-<summary>Configuration Options</summary>
+## Configuration Options
 
-The following options are presented when adding a Google account, and (except for username) when reconfiguring it (i.e., via the `CONFIGURE` button.)
+### Account Data
 
-### Google Maps Account Username
+These data items are shown when adding a new account or when reconfiguring the account,
+either manually (integration entry three-dot menu -> Reconfigure) or when an automatic reconfiguration is started due to expired cookies.
+
+#### Google Maps Account Email Address
 
 The email address for the Google account to be used for retrieving shared location.
 
-### Cookies File
+> NOTE: **This value is _not_ used to verify the associated cookies file.**
+It is only used to set the title of the integration entry and its service
+as well as the name, entity ID & unique ID of the "[Account Tracker Entity](#account-tracker-entity)", if enabled.
+#### Cookies File
 
 A cookies file must be [obtained](#obtaining-a-cookies-file) that authenticates and authorizes the user to access the specified Google account.
 If a cookies file exists from the legacy implementation, and it is still valid, an option will be presented to use that file.
 If not, a new cookies file can be uploaded via file browsing or drag & drop.
 There is no requirement for the file's name as there was in the legacy implementation.
 
-### Account Tracker Entity
+### Account Options
+
+These options are shown when adding a new account or when manually initiated (integration entry Configure button.)
+
+#### Account Tracker Entity
 
 The Google account specified above is used to create `device_tracker` entities for everyone who has shared their location with that account.
 In addition to those shared accounts, the integration can also create a tracker for the account itself if it has been associated with a device (phone, etc.)
@@ -162,7 +171,7 @@ Since there may not be a device associated with the account, or even if there is
 an option is provided to enable or disable the creation of this "account tracker" entity.
 See [Account Strategies](account-strategies) for more detail.
 
-### GPS Accuracy Limit
+#### GPS Accuracy Limit
 
 Each location update has an accuracy value that, together with the latitude & longitude, describes a circular area in which the device may actually be.
 Under certain conditions (poor GPS, cell or network coverage, etc.) that accuracy value can become quite large.
@@ -175,11 +184,9 @@ If, however, the reported accuracy is _more than_ the specified limit, then the 
 
 See the description above about "Refined Filtering of Data Updates" for more information about how this limit is used.
 
-### Update Period
+#### Update Period
 
 This option controls the time between requests for updates.
-
-</details>
 
 ## Missing Data for Account Tracker
 
@@ -188,7 +195,7 @@ will be missing some data that is usually present for the tracker entities creat
 Specifically, the name (and entity ID) will be based on the email address, not the actual name associated with the account,
 and the following attributes will be missing or invalid:
 
-`battery_charging`, `battery_level`, `entity_picture`, `full_name` & `nickname`
+`battery_charging`, `battery_level`, `entity_picture` & `nickname`
 
 All other attributes, including those related to location, will be present and valid.
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ After it has been downloaded you will need to restart Home Assistant.
 
 ### Versions
 
-This custom integration supports HomeAssistant versions 2024.8.3 or newer.
+This custom integration supports HomeAssistant versions 2024.12.0 or newer.
 
 ## Configuration
 

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -151,8 +151,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
         # Release all the unique IDs that were "owned" by this config entry.
         hass.data[CFG_UNIQUE_IDS].release_all(ConfigID(entry.entry_id))
     else:
-        # Entry is being reloaded, possibly due to a reauthentication, reconfiguration,
-        # options update or a manual reload initiated by the user.
+        # It's possible entry is being reloaded due to a reauthentication,
+        # reconfiguration or an options update. So check if any entry data or options
+        # have changed that require further processing.
         if (
             not entry.options[CONF_CREATE_ACCT_ENTITY]
             and entry.runtime_data.setup_options[CONF_CREATE_ACCT_ENTITY]

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -104,9 +104,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up config entry."""
     coordinator = GMDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
-    entry.runtime_data = GMConfigEntryParams(
-        coordinator, entry.options[CONF_CREATE_ACCT_ENTITY]
-    )
+    entry.runtime_data = GMConfigEntryParams(coordinator, entry)
 
     # TODO: After dropping support for HA versions before 2025.8, entry_updated can be
     #       removed if GoogleMapsOptionsFlow is based on OptionsFlowWithReload instead
@@ -121,6 +119,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _del_cookies_file(hass: HomeAssistant, cookies_file: str) -> None:
+    """Delete cookies file."""
+    hass.async_add_executor_job(
+        partial(cookies_file_path(hass, cookies_file).unlink, missing_ok=True)
+    )
+
+
 async def async_unload_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
     """Unload a config entry."""
     result = await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
@@ -129,36 +134,38 @@ async def async_unload_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
         # Entry was just disabled.
         # Release all the unique IDs that were "owned" by this config entry.
         hass.data[CFG_UNIQUE_IDS].release_all(ConfigID(entry.entry_id))
-    elif (
-        entry.runtime_data.setup_with_acct_entity
-        and not entry.options[CONF_CREATE_ACCT_ENTITY]
-    ):
-        # The "account entity" option was enabled when the entry was setup but it is not
-        # now. This must be because the user just changed that option, causing the entry
-        # to be reloaded. Since the option is no longer enabled, clean up the entity &
-        # device registry entries that were created for it.
+    else:
+        # Entry is being reloaded, possibly due to a reauthentication, reconfiguration,
+        # options update or a manual reload initiated by the user.
+        if (
+            not entry.options[CONF_CREATE_ACCT_ENTITY]
+            and entry.runtime_data.setup_options[CONF_CREATE_ACCT_ENTITY]
+        ):
+            # User turned off the "account entity" option. Clean up the entity & device
+            # registry entries that were created for it.
 
-        # The "account" entity's unique ID is the config entry's username, aka the
-        # account's email address, which is also the config entry's unique ID.
-        uid = UniqueID(cast(str, entry.unique_id))
+            # The "account" entity's unique ID is the config entry's username, aka the
+            # account's email address, which is also the config entry's unique ID.
+            uid = UniqueID(cast(str, entry.unique_id))
 
-        ent_reg = er.async_get(hass)
-        if entity_id := ent_reg.async_get_entity_id(DT_DOMAIN, DOMAIN, uid):
-            ent_reg.async_remove(entity_id)
-        dev_reg = dr.async_get(hass)
-        if device := dev_reg.async_get_device(dev_ids(uid)):
-            dev_reg.async_remove_device(device.id)
+            ent_reg = er.async_get(hass)
+            if entity_id := ent_reg.async_get_entity_id(DT_DOMAIN, DOMAIN, uid):
+                ent_reg.async_remove(entity_id)
+            dev_reg = dr.async_get(hass)
+            if device := dev_reg.async_get_device(dev_ids(uid)):
+                dev_reg.async_remove_device(device.id)
+
+        if entry.options[CONF_COOKIES_FILE] != (
+            cookies_file := entry.runtime_data.setup_options[CONF_COOKIES_FILE]
+        ):
+            # Cookies file has changed. Delete the old one.
+            _del_cookies_file(hass, cookies_file)
 
     return result
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove a config entry."""
-    hass.async_add_executor_job(
-        partial(
-            cookies_file_path(hass, entry.options[CONF_COOKIES_FILE]).unlink,
-            missing_ok=True,
-        )
-    )
+    _del_cookies_file(hass, entry.options[CONF_COOKIES_FILE])
     if not _duplicate_usernames(hass):
         ir.async_delete_issue(hass, DOMAIN, "duplicate_usernames")

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.typing import ConfigType
 
+from .config_flow import GoogleMapsConfigFlow
 from .const import CONF_COOKIES_FILE, CONF_CREATE_ACCT_ENTITY, DOMAIN
 from .coordinator import GMConfigEntry, GMConfigEntryParams, GMDataUpdateCoordinator
 from .helpers import (
@@ -76,7 +77,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate config entry."""
     _LOGGER.warning("%s: Migrating from version %s", entry.title, entry.version)
 
-    if entry.version > 3:
+    if entry.version > GoogleMapsConfigFlow.VERSION:
         # Can't downgrade from some unknown future version.
         return False
 
@@ -85,14 +86,29 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unique_id = entry.unique_id
 
     if entry.version == 1:
+        # Move CONF_COOKIES_FILE data -> options.
         options[CONF_COOKIES_FILE] = data.pop(CONF_COOKIES_FILE)
 
     if entry.version <= 2:
+        # Move CONF_USERNAME data -> unique_id.
         unique_id = cast(str, data.pop(CONF_USERNAME))
-        # TODO: Put CONF_COOKIES_FILE back in data (to support reconfig flow)???
+
+    if entry.version <= 3:
+        # Move CONF_COOKIES_FILE options -> data.
+        # Put CONF_COOKIES_FILE back in data to support reauth & reconfigure flows.
+        # It's not really an "option". It was only there when there wasn't such a thing
+        # as a reconfigure flow.
+        data[CONF_COOKIES_FILE] = options.pop(CONF_COOKIES_FILE)
+
+    # TODO: Before releasing BETA, merge versions 3 & 4!!
+    #       I.e., put "<= 3" statements into "<= 2", and change VERSION back to 3.
 
     hass.config_entries.async_update_entry(
-        entry, data=data, options=options, unique_id=unique_id, version=3
+        entry,
+        data=data,
+        options=options,
+        unique_id=unique_id,
+        version=GoogleMapsConfigFlow.VERSION,
     )
     _LOGGER.warning(
         "%s: Migration to version %s successful", entry.title, entry.version
@@ -155,8 +171,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
             if device := dev_reg.async_get_device(dev_ids(uid)):
                 dev_reg.async_remove_device(device.id)
 
-        if entry.options[CONF_COOKIES_FILE] != (
-            cookies_file := entry.runtime_data.setup_options[CONF_COOKIES_FILE]
+        if entry.data[CONF_COOKIES_FILE] != (
+            cookies_file := entry.runtime_data.setup_data[CONF_COOKIES_FILE]
         ):
             # Cookies file has changed. Delete the old one.
             _del_cookies_file(hass, cookies_file)
@@ -166,6 +182,6 @@ async def async_unload_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove a config entry."""
-    _del_cookies_file(hass, entry.options[CONF_COOKIES_FILE])
+    _del_cookies_file(hass, entry.data[CONF_COOKIES_FILE])
     if not _duplicate_usernames(hass):
         ir.async_delete_issue(hass, DOMAIN, "duplicate_usernames")

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -7,16 +7,24 @@ import logging
 from homeassistant.components.device_tracker import DOMAIN as DT_DOMAIN
 from homeassistant.const import CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
     entity_registry as er,
+    issue_registry as ir,
 )
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_COOKIES_FILE, CONF_CREATE_ACCT_ENTITY, DOMAIN, NAME_PREFIX
-from .coordinator import GMConfigEntry, GMDataUpdateCoordinator
-from .helpers import CFG_UNIQUE_IDS, ConfigID, ConfigUniqueIDs, cookies_file_path
+from .const import CONF_COOKIES_FILE, CONF_CREATE_ACCT_ENTITY, DOMAIN
+from .coordinator import GMConfigEntry, GMConfigEntryParams, GMDataUpdateCoordinator
+from .helpers import (
+    CFG_UNIQUE_IDS,
+    ConfigID,
+    ConfigUniqueIDs,
+    cookies_file_path,
+    dev_ids,
+)
 
 _LOGGER = logging.getLogger(__name__)
 _PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
@@ -24,20 +32,43 @@ _PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
+def _duplicate_usernames(hass: HomeAssistant) -> list[str]:
+    """Check configs for duplicate usernames."""
+    username_cfgs: dict[str, list[GMConfigEntry]] = {}
+    for cfg in hass.config_entries.async_entries(DOMAIN):
+        username_cfgs.setdefault(cfg.data[CONF_USERNAME], []).append(cfg)
+    return [username for username, cfgs in username_cfgs.items() if len(cfgs) > 1]
+
+
 async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
     """Set up integration."""
+    # In previous integration versions it was possible to create more than one config
+    # entry with the same username. This is no longer allowed.
+    #
+    # If the user had created multiple entries that shared the same username while using
+    # a previous integration version, warn them via a repair issue that they need to
+    # remove all but one entry per username.
+    if duplicate_usernames := sorted(_duplicate_usernames(hass)):
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "duplicate_usernames",
+            # TODO: Make it fixable and add repair flow that for each reused username,
+            #       show list of configs using it and ask which to enable and whether or
+            #       not to remove the others???
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="duplicate_usernames",
+            translation_placeholders={"usernames": ", ".join(duplicate_usernames)},
+        )
+
     hass.data[CFG_UNIQUE_IDS] = ConfigUniqueIDs(hass)
     return True
 
 
-async def entry_updated(hass: HomeAssistant, entry: GMConfigEntry) -> None:
-    """Handle config entry update."""
-    await hass.config_entries.async_reload(entry.entry_id)
-
-
 async def async_migrate_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
     """Migrate config entry."""
-    _LOGGER.debug("%s: Migrating from version %s", entry.title, entry.version)
+    _LOGGER.warning("%s: Migrating from version %s", entry.title, entry.version)
 
     if entry.version > 2:
         # Can't downgrade from some unknown future version.
@@ -47,65 +78,83 @@ async def async_migrate_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool
         data = dict(entry.data)
         options = dict(entry.options)
         options[CONF_COOKIES_FILE] = data.pop(CONF_COOKIES_FILE)
-        try:
-            hass.config_entries.async_update_entry(
-                entry, data=data, options=options, version=2
-            )
-        except TypeError:
-            # 2024.2 and earlier did not accept version as a parameter.
-            entry.version = 2
-            hass.config_entries.async_update_entry(entry, data=data, options=options)
+        hass.config_entries.async_update_entry(
+            entry, data=data, options=options, version=2
+        )
 
-    _LOGGER.debug("%s: Migration to version %s successful", entry.title, entry.version)
+    _LOGGER.warning(
+        "%s: Migration to version %s successful", entry.title, entry.version
+    )
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
     """Set up config entry."""
-    cid = ConfigID(entry.entry_id)
-    username = entry.data[CONF_USERNAME]
-    create_acct_entity = entry.options[CONF_CREATE_ACCT_ENTITY]
-
-    # For "account person", unique ID is username (which is also returned in person.id.)
-    ent_reg = er.async_get(hass)
-    unique_ids = hass.data[CFG_UNIQUE_IDS]
-    if create_acct_entity:
-        if not unique_ids.own(cid, username) and unique_ids.take(cid, {username}):
-            ent_reg.async_get_or_create(
-                DT_DOMAIN,
-                DOMAIN,
-                username,
-                config_entry=entry,
-                original_name=f"{NAME_PREFIX} {username}",
-            )
-    elif unique_ids.own(cid, username):
-        if entity_id := ent_reg.async_get_entity_id(DT_DOMAIN, DOMAIN, username):
-            ent_reg.async_remove(entity_id)
-        dev_reg = dr.async_get(hass)
-        if device := dev_reg.async_get_device({(DOMAIN, username)}):
-            dev_reg.async_remove_device(device.id)
-        unique_ids.release(cid, username)
+    # Per the comment in async_setup, multiple config entries using the same username is
+    # no longer allowed. However, if the user had created this situation with an older
+    # integration version, refuse to setup any config entries that share a username with
+    # other entries.
+    if (username := entry.data[CONF_USERNAME]) in _duplicate_usernames(hass):
+        # Normally unique IDs would be released when the config entry is unloaded.
+        # However, since this one is failing to load, release any it might have owned
+        # per the Entity Registry.
+        hass.data[CFG_UNIQUE_IDS].release_all(ConfigID(entry.entry_id))
+        raise ConfigEntryError(
+            f"Username {username} used by multiple integration entries"
+        )
 
     coordinator = GMDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
-    entry.runtime_data = coordinator
+    entry.runtime_data = GMConfigEntryParams(
+        coordinator, entry.options[CONF_CREATE_ACCT_ENTITY]
+    )
+
+    # TODO: After dropping support for HA versions before 2025.8, entry_updated can be
+    #       removed if GoogleMapsOptionsFlow is based on OptionsFlowWithReload instead
+    #       of OptionsFlow.
+    async def entry_updated(hass: HomeAssistant, entry: GMConfigEntry) -> None:
+        """Handle config entry update."""
+        await hass.config_entries.async_reload(entry.entry_id)
 
     entry.async_on_unload(entry.add_update_listener(entry_updated))
+
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
     """Unload a config entry."""
-    return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+    result = await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+    # Clean up entity & device registry entries for "account entity" if config entry was
+    # setup with that option enabled but it is no longer enabled (i.e., this option was
+    # just turned off by user, causing the config entry to be reloaded.)
+    if (
+        entry.runtime_data.setup_with_acct_entity
+        and not entry.options[CONF_CREATE_ACCT_ENTITY]
+    ):
+        # This shouldn't be able to happen if the config entry is now disabled.
+        # I.e., if it's getting unloaded due to being disabled, it can't also have had
+        # its options changed.
+        assert not entry.disabled_by
+
+        username = entry.data[CONF_USERNAME]
+        ent_reg = er.async_get(hass)
+        if entity_id := ent_reg.async_get_entity_id(DT_DOMAIN, DOMAIN, username):
+            ent_reg.async_remove(entity_id)
+        dev_reg = dr.async_get(hass)
+        if device := dev_reg.async_get_device(dev_ids(username)):
+            dev_reg.async_remove_device(device.id)
+    hass.data[CFG_UNIQUE_IDS].release_all(ConfigID(entry.entry_id))
+    return result
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: GMConfigEntry) -> None:
     """Remove a config entry."""
-    hass.data[CFG_UNIQUE_IDS].remove(ConfigID(entry.entry_id))
     hass.async_add_executor_job(
         partial(
-            cookies_file_path(hass, entry.data[CONF_COOKIES_FILE]).unlink,
+            cookies_file_path(hass, entry.options[CONF_COOKIES_FILE]).unlink,
             missing_ok=True,
         )
     )
+    if not _duplicate_usernames(hass):
+        ir.async_delete_issue(hass, DOMAIN, "duplicate_usernames")

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -86,22 +86,22 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unique_id = entry.unique_id
 
     if entry.version == 1:
+        # 1 -> 2
+
         # Move CONF_COOKIES_FILE data -> options.
         options[CONF_COOKIES_FILE] = data.pop(CONF_COOKIES_FILE)
 
     if entry.version <= 2:
+        # 2 -> 3
+
         # Move CONF_USERNAME data -> unique_id.
         unique_id = cast(str, data.pop(CONF_USERNAME))
 
-    if entry.version <= 3:
         # Move CONF_COOKIES_FILE options -> data.
         # Put CONF_COOKIES_FILE back in data to support reauth & reconfigure flows.
         # It's not really an "option". It was only there when there wasn't such a thing
         # as a reconfigure flow.
         data[CONF_COOKIES_FILE] = options.pop(CONF_COOKIES_FILE)
-
-    # TODO: Before releasing BETA, merge versions 3 & 4!!
-    #       I.e., put "<= 3" statements into "<= 2", and change VERSION back to 3.
 
     hass.config_entries.async_update_entry(
         entry,
@@ -182,6 +182,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove a config entry."""
-    _del_cookies_file(hass, entry.data[CONF_COOKIES_FILE])
+    # CONF_COOKIES_FILE is in data for config versions 1 & 3, but was in options for
+    # version 2. In case an old, disabled config entry is being deleted, try getting it
+    # from both places.
+    _del_cookies_file(
+        hass, entry.data.get(CONF_COOKIES_FILE, entry.options[CONF_COOKIES_FILE])
+    )
     if not _duplicate_usernames(hass):
         ir.async_delete_issue(hass, DOMAIN, "duplicate_usernames")

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 from functools import partial
 import logging
+from typing import cast
 
 from homeassistant.components.device_tracker import DOMAIN as DT_DOMAIN
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
@@ -22,6 +23,7 @@ from .helpers import (
     CFG_UNIQUE_IDS,
     ConfigID,
     ConfigUniqueIDs,
+    UniqueID,
     cookies_file_path,
     dev_ids,
 )
@@ -33,10 +35,13 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 def _duplicate_usernames(hass: HomeAssistant) -> list[str]:
-    """Check configs for duplicate usernames."""
-    username_cfgs: dict[str, list[GMConfigEntry]] = {}
+    """Return duplicate usernames in config entries."""
+    username_cfgs: dict[str, list[ConfigEntry]] = {}
     for cfg in hass.config_entries.async_entries(DOMAIN):
-        username_cfgs.setdefault(cfg.data[CONF_USERNAME], []).append(cfg)
+        username_cfgs.setdefault(
+            cast(str, cfg.data[CONF_USERNAME] if cfg.version < 3 else cfg.unique_id),
+            [],
+        ).append(cfg)
     return [username for username, cfgs in username_cfgs.items() if len(cfgs) > 1]
 
 
@@ -46,8 +51,8 @@ async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
     # entry with the same username. This is no longer allowed.
     #
     # If the user had created multiple entries that shared the same username while using
-    # a previous integration version, warn them via a repair issue that they need to
-    # remove all but one entry per username.
+    # a previous integration version, create a repair issue that tells user they need to
+    # remove all but one entry per username and abort setup (until user fixes problem.)
     if duplicate_usernames := sorted(_duplicate_usernames(hass)):
         ir.async_create_issue(
             hass,
@@ -61,48 +66,42 @@ async def async_setup(hass: HomeAssistant, _: ConfigType) -> bool:
             translation_key="duplicate_usernames",
             translation_placeholders={"usernames": ", ".join(duplicate_usernames)},
         )
+        return False
 
     hass.data[CFG_UNIQUE_IDS] = ConfigUniqueIDs(hass)
     return True
 
 
-async def async_migrate_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate config entry."""
     _LOGGER.warning("%s: Migrating from version %s", entry.title, entry.version)
 
-    if entry.version > 2:
+    if entry.version > 3:
         # Can't downgrade from some unknown future version.
         return False
 
-    if entry.version == 1:
-        data = dict(entry.data)
-        options = dict(entry.options)
-        options[CONF_COOKIES_FILE] = data.pop(CONF_COOKIES_FILE)
-        hass.config_entries.async_update_entry(
-            entry, data=data, options=options, version=2
-        )
+    data = dict(entry.data)
+    options = dict(entry.options)
+    unique_id = entry.unique_id
 
+    if entry.version == 1:
+        options[CONF_COOKIES_FILE] = data.pop(CONF_COOKIES_FILE)
+
+    if entry.version <= 2:
+        unique_id = cast(str, data.pop(CONF_USERNAME))
+        # TODO: Put CONF_COOKIES_FILE back in data (to support reconfig flow)???
+
+    hass.config_entries.async_update_entry(
+        entry, data=data, options=options, unique_id=unique_id, version=3
+    )
     _LOGGER.warning(
         "%s: Migration to version %s successful", entry.title, entry.version
     )
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up config entry."""
-    # Per the comment in async_setup, multiple config entries using the same username is
-    # no longer allowed. However, if the user had created this situation with an older
-    # integration version, refuse to setup any config entries that share a username with
-    # other entries.
-    if (username := entry.data[CONF_USERNAME]) in _duplicate_usernames(hass):
-        # Normally unique IDs would be released when the config entry is unloaded.
-        # However, since this one is failing to load, release any it might have owned
-        # per the Entity Registry.
-        hass.data[CFG_UNIQUE_IDS].release_all(ConfigID(entry.entry_id))
-        raise ConfigEntryError(
-            f"Username {username} used by multiple integration entries"
-        )
-
     coordinator = GMDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = GMConfigEntryParams(
@@ -112,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
     # TODO: After dropping support for HA versions before 2025.8, entry_updated can be
     #       removed if GoogleMapsOptionsFlow is based on OptionsFlowWithReload instead
     #       of OptionsFlow.
-    async def entry_updated(hass: HomeAssistant, entry: GMConfigEntry) -> None:
+    async def entry_updated(hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Handle config entry update."""
         await hass.config_entries.async_reload(entry.entry_id)
 
@@ -125,30 +124,35 @@ async def async_setup_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: GMConfigEntry) -> bool:
     """Unload a config entry."""
     result = await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
-    # Clean up entity & device registry entries for "account entity" if config entry was
-    # setup with that option enabled but it is no longer enabled (i.e., this option was
-    # just turned off by user, causing the config entry to be reloaded.)
-    if (
+
+    if entry.disabled_by:
+        # Entry was just disabled.
+        # Release all the unique IDs that were "owned" by this config entry.
+        hass.data[CFG_UNIQUE_IDS].release_all(ConfigID(entry.entry_id))
+    elif (
         entry.runtime_data.setup_with_acct_entity
         and not entry.options[CONF_CREATE_ACCT_ENTITY]
     ):
-        # This shouldn't be able to happen if the config entry is now disabled.
-        # I.e., if it's getting unloaded due to being disabled, it can't also have had
-        # its options changed.
-        assert not entry.disabled_by
+        # The "account entity" option was enabled when the entry was setup but it is not
+        # now. This must be because the user just changed that option, causing the entry
+        # to be reloaded. Since the option is no longer enabled, clean up the entity &
+        # device registry entries that were created for it.
 
-        username = entry.data[CONF_USERNAME]
+        # The "account" entity's unique ID is the config entry's username, aka the
+        # account's email address, which is also the config entry's unique ID.
+        uid = UniqueID(cast(str, entry.unique_id))
+
         ent_reg = er.async_get(hass)
-        if entity_id := ent_reg.async_get_entity_id(DT_DOMAIN, DOMAIN, username):
+        if entity_id := ent_reg.async_get_entity_id(DT_DOMAIN, DOMAIN, uid):
             ent_reg.async_remove(entity_id)
         dev_reg = dr.async_get(hass)
-        if device := dev_reg.async_get_device(dev_ids(username)):
+        if device := dev_reg.async_get_device(dev_ids(uid)):
             dev_reg.async_remove_device(device.id)
-    hass.data[CFG_UNIQUE_IDS].release_all(ConfigID(entry.entry_id))
+
     return result
 
 
-async def async_remove_entry(hass: HomeAssistant, entry: GMConfigEntry) -> None:
+async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove a config entry."""
     hass.async_add_executor_job(
         partial(

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -1,6 +1,7 @@
 """The google_maps component."""
 from __future__ import annotations
 
+from collections import defaultdict
 from functools import partial
 import logging
 from typing import cast
@@ -36,12 +37,11 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 def _duplicate_usernames(hass: HomeAssistant) -> list[str]:
     """Return duplicate usernames in config entries."""
-    username_cfgs: dict[str, list[ConfigEntry]] = {}
+    username_cfgs: defaultdict[str, list[ConfigEntry]] = defaultdict(list)
     for cfg in hass.config_entries.async_entries(DOMAIN):
-        username_cfgs.setdefault(
-            cast(str, cfg.data[CONF_USERNAME] if cfg.version < 3 else cfg.unique_id),
-            [],
-        ).append(cfg)
+        username_cfgs[
+            cast(str, cfg.data[CONF_USERNAME] if cfg.version < 3 else cfg.unique_id)
+        ].append(cfg)
     return [username for username, cfgs in username_cfgs.items() if len(cfgs) > 1]
 
 

--- a/custom_components/google_maps/binary_sensor.py
+++ b/custom_components/google_maps/binary_sensor.py
@@ -1,6 +1,8 @@
 """Google Maps binary sensor."""
 from __future__ import annotations
 
+from propcache.api import cached_property
+
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -8,7 +10,6 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTION
@@ -38,30 +39,16 @@ class GoogleMapsBinarySensor(
         super().__init__(coordinator)
         entry = coordinator.config_entry
         self._attr_unique_id = uid = UniqueID(entry.entry_id)
-        self._attr_translation_placeholders = {"title": entry.title}
+        name = f"Google Maps {entry.title}"
         self._attr_device_info = dr.DeviceInfo(
-            entry_type=dr.DeviceEntryType.SERVICE,
-            identifiers=dev_ids(uid),
-            name=entry.title,
+            entry_type=dr.DeviceEntryType.SERVICE, identifiers=dev_ids(uid), name=name
         )
         self._attr_is_on = super().available
 
-    @property
+    @cached_property
     def available(self) -> bool:
         """Return if entity is available."""
         return True
-
-    def _friendly_name_internal(self) -> str | None:
-        """Return the friendly name.
-
-        It does not make sense to use device name in front of entity name since device
-        name is effectively part of entity name since they both come from config entry
-        title.
-        """
-        name = self.name
-        if name is UNDEFINED:
-            return None
-        return name
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/google_maps/binary_sensor.py
+++ b/custom_components/google_maps/binary_sensor.py
@@ -6,20 +6,21 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, NAME_PREFIX
+from .const import ATTRIBUTION
 from .coordinator import GMConfigEntry, GMDataUpdateCoordinator
+from .helpers import UniqueID, dev_ids
 
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: GMConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the binary sensor platform."""
-    coordinator = entry.runtime_data
-
-    async_add_entities([GoogleMapsBinarySensor(coordinator)])
+    async_add_entities([GoogleMapsBinarySensor(entry.runtime_data.coordinator)])
 
 
 class GoogleMapsBinarySensor(
@@ -28,20 +29,39 @@ class GoogleMapsBinarySensor(
     """Google Maps Binary Sensor."""
 
     _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_translation_key = "online"
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
 
     def __init__(self, coordinator: GMDataUpdateCoordinator) -> None:
         """Initialize Google Maps Binary Sensor."""
         super().__init__(coordinator)
         entry = coordinator.config_entry
-        self._attr_unique_id = entry.entry_id
-        self._attr_name = f"{NAME_PREFIX} {entry.title} online"
+        self._attr_unique_id = uid = UniqueID(entry.entry_id)
+        self._attr_translation_placeholders = {"title": entry.title}
+        self._attr_device_info = dr.DeviceInfo(
+            entry_type=dr.DeviceEntryType.SERVICE,
+            identifiers=dev_ids(uid),
+            name=entry.title,
+        )
         self._attr_is_on = super().available
 
     @property
     def available(self) -> bool:
         """Return if entity is available."""
         return True
+
+    def _friendly_name_internal(self) -> str | None:
+        """Return the friendly name.
+
+        It does not make sense to use device name in front of entity name since device
+        name is effectively part of entity name since they both come from config entry
+        title.
+        """
+        name = self.name
+        if name is UNDEFINED:
+            return None
+        return name
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/google_maps/config_flow.py
+++ b/custom_components/google_maps/config_flow.py
@@ -235,14 +235,19 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
             # being changed, then the entry using it must be the one being updated.
             if update_entry:
                 if not entry_w_username or entry_w_username is update_entry:
-                    self._init_gmcfgflow(
-                        username, update_entry.options, update_entry.data
+                    await self.hass.async_add_executor_job(
+                        self._init_gmcfgflow,
+                        username,
+                        update_entry.options,
+                        update_entry.data,
                     )
                     return await self.async_step_check_cookies()
             # If creating a new entry, then no other existing entry can be using the
             # same username.
             elif not entry_w_username:
-                self._init_gmcfgflow(username, {}, {})
+                await self.hass.async_add_executor_job(
+                    self._init_gmcfgflow, username, {}, {}
+                )
                 return await self.async_step_get_cookies()
             errors[CONF_USERNAME] = "already_configured"
         elif update_entry:

--- a/custom_components/google_maps/config_flow.py
+++ b/custom_components/google_maps/config_flow.py
@@ -17,6 +17,7 @@ import voluptuous as vol
 from homeassistant.components.file_upload import process_uploaded_file
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
     ConfigEntry,
     ConfigEntryBaseFlow,
     ConfigFlow,
@@ -75,17 +76,15 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
     _expiration: datetime | None
 
     @cached_property
-    def _is_reauth(self) -> bool:
-        """Return if this is a re-authentication config flow."""
-        return self.source == SOURCE_REAUTH
+    def _is_existing(self) -> bool:
+        """Return if this is a config flow for an existing config entry."""
+        return self.source in (SOURCE_REAUTH, SOURCE_RECONFIGURE)
 
-    def _init_flow_params(
-        self, username: str, options: Mapping[str, Any] | None = None
-    ) -> None:
+    def _init_flow_params(self, username: str, options: Mapping[str, Any]) -> None:
         """Initialize flow parameters."""
         self._username = username
         self._api = GMLocSharing(username)
-        self._options = deepcopy(dict(options or {}))
+        self._options = deepcopy(dict(options))
 
     def _cookies_file_ok(self, cookies_file: str | PathLike) -> bool:
         """Determine if cookies in file are ok.
@@ -120,19 +119,31 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
         cf_path.parent.mkdir(exist_ok=True)
         self._api.save_cookies(str(cf_path))
 
+    async def _existing_cookies_file_ok(self, entry: GMConfigEntry) -> bool:
+        """Return if existing cookies file is ok."""
+        if hasattr(entry, "runtime_data"):
+            lock = entry.runtime_data.coordinator.cookie_lock
+        else:
+            lock = Lock()
+        async with lock:
+            return await self.hass.async_add_executor_job(
+                self._cookies_file_ok,
+                cookies_file_path(self.hass, entry.options[CONF_COOKIES_FILE]),
+            )
+
     async def _save_new_cookies(self) -> None:
         """Save new cookies to newly named file."""
         self._options[CONF_COOKIES_FILE] = cookies_file = random_uuid_hex()
         await self.hass.async_add_executor_job(self._save_cookies, cookies_file)
 
-    async def async_step_cookies(
+    async def async_step_get_cookies(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Get a cookies file."""
         if user_input is not None:
             if not user_input[_CONF_USE_EXISTING_COOKIES]:
                 return await self.async_step_get_cookies_procedure_menu()
-            if self._is_reauth:
+            if self._is_existing:
                 return await self.async_step_done()
             return await self.async_step_account_entity()
 
@@ -149,7 +160,7 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
             data_schema, {_CONF_USE_EXISTING_COOKIES: True}
         )
         return self.async_show_form(
-            step_id="cookies",
+            step_id="get_cookies",
             data_schema=data_schema,
             description_placeholders={
                 "username": self._username,
@@ -257,7 +268,7 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Use uploaded cookie file or try again."""
         menu_options = [
-            "reauth_done" if self._is_reauth else "account_entity",
+            "done" if self._is_existing else "account_entity",
             "get_cookies_procedure_menu",
         ]
         return self.async_show_menu(
@@ -355,6 +366,9 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
 
     VERSION = 3
 
+    _update_entry: GMConfigEntry | None = None
+    _get_new_cookies = True
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> GoogleMapsOptionsFlow:
@@ -369,20 +383,46 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, data: Mapping[str, Any]) -> ConfigFlowResult:
         """Start reauthorization flow."""
-        assert self.unique_id
-        self._init_flow_params(self.unique_id, self._get_reauth_entry().options)
-        return await self.async_step_cookies()
+        self._update_entry = self._get_reauth_entry()
+        return await self.async_step_username()
+
+    async def async_step_reconfigure(self, data: Mapping[str, Any]) -> ConfigFlowResult:
+        """Start reconfiguration flow."""
+        self._update_entry = self._get_reconfigure_entry()
+        return await self.async_step_username()
 
     async def async_step_username(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Get username."""
+        errors = {}
+        username: str | None
+
         if user_input is not None:
-            username = user_input[CONF_USERNAME]
-            await self.async_set_unique_id(username)
-            self._abort_if_unique_id_configured()
-            self._init_flow_params(username)
-            return await self.async_step_cookies()
+            username = cast(str, user_input[CONF_USERNAME])
+            # Set unique ID to username and see if any existing config entries are
+            # already using that username.
+            entry_w_username = await self.async_set_unique_id(username)
+            # If entry is being updated (reauth or reconfig), then the username must not
+            # be in use by another config entry, or if it is, it must be the entry being
+            # updated. To put that another way, if the username is being changed, then
+            # it can't be already in use by another config, or if it's not being
+            # being changed, then the entry using it must be the one being updated.
+            if self._update_entry:
+                if not entry_w_username or entry_w_username is self._update_entry:
+                    self._init_flow_params(username, self._update_entry.options)
+                    return await self.async_step_check_cookies()
+            # If creating a new entry, then no other existing entry can be using the
+            # same username.
+            elif not entry_w_username:
+                self._init_flow_params(username, {})
+                return await self.async_step_get_cookies()
+            errors[CONF_USERNAME] = "already_configured"
+        elif self._update_entry:
+            username = self._update_entry.unique_id
+            assert username
+        else:
+            username = None
 
         data_schema = vol.Schema(
             {
@@ -391,8 +431,42 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
                 )
             }
         )
+        if username:
+            data_schema = self.add_suggested_values_to_schema(
+                data_schema, {CONF_USERNAME: username}
+            )
         return self.async_show_form(
-            step_id="username", data_schema=data_schema, last_step=False
+            step_id="username", data_schema=data_schema, errors=errors, last_step=False
+        )
+
+    async def async_step_check_cookies(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Get username."""
+
+        if user_input is not None:
+            if user_input[_CONF_UPDATE_COOKIES]:
+                return await self.async_step_get_cookies()
+            self._get_new_cookies = False
+            return await self.async_step_done()
+
+        assert self._update_entry
+        file_ok = await self._existing_cookies_file_ok(self._update_entry)
+        data_schema = vol.Schema(
+            {vol.Required(_CONF_UPDATE_COOKIES): BooleanSelector()}
+        )
+        data_schema = self.add_suggested_values_to_schema(
+            data_schema,
+            {_CONF_UPDATE_COOKIES: not file_ok or expiring_soon(self._expiration)},
+        )
+        return self.async_show_form(
+            step_id="check_cookies",
+            data_schema=data_schema,
+            description_placeholders={
+                "username": self._username,
+                "expiration": exp_2_str(self._expiration),
+            },
+            last_step=False,
         )
 
     async def async_step_done(
@@ -400,14 +474,23 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Finish the config flow."""
         # Save cookies.
-        await self._save_new_cookies()
+        if self._get_new_cookies:
+            await self._save_new_cookies()
 
-        if self._is_reauth:
+        if self._update_entry:
+            assert self.unique_id == self._username
             self.hass.config_entries.async_update_entry(
-                self._get_reauth_entry(), options=self._options
+                self._update_entry,
+                options=self._options,
+                title=self._username,
+                unique_id=self.unique_id,
             )
-            _LOGGER.debug("Reauthorization successful")
-            return self.async_abort(reason="reauth_successful")
+            if self.source == SOURCE_REAUTH:
+                action = "Re-authentication"
+            else:
+                action = "Re-configuration"
+            _LOGGER.debug("%s was successful", action)
+            return self.async_abort(reason=f"{self.source}_successful")
 
         return self.async_create_entry(
             title=self._username,
@@ -419,7 +502,7 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
 class GoogleMapsOptionsFlow(OptionsFlow, GoogleMapsFlow):
     """Google Maps options flow."""
 
-    _update_cookies = False
+    _get_new_cookies = False
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -427,26 +510,15 @@ class GoogleMapsOptionsFlow(OptionsFlow, GoogleMapsFlow):
         """Start options flow."""
         if user_input is not None:
             if user_input[_CONF_UPDATE_COOKIES]:
-                self._update_cookies = True
-                return await self.async_step_cookies()
+                self._get_new_cookies = True
+                return await self.async_step_get_cookies()
             return await self.async_step_account_entity()
 
         username = self.config_entry.unique_id
         assert username
         self._init_flow_params(username, self.config_entry.options)
-        if hasattr(self.config_entry, "runtime_data"):
-            lock = cast(
-                GMConfigEntry, self.config_entry
-            ).runtime_data.coordinator.cookie_lock
-        else:
-            lock = Lock()
-        async with lock:
-            file_ok = await self.hass.async_add_executor_job(
-                self._cookies_file_ok,
-                cookies_file_path(
-                    self.hass, self.config_entry.options[CONF_COOKIES_FILE]
-                ),
-            )
+
+        file_ok = await self._existing_cookies_file_ok(self.config_entry)
         data_schema = vol.Schema(
             {vol.Required(_CONF_UPDATE_COOKIES): BooleanSelector()}
         )
@@ -468,7 +540,7 @@ class GoogleMapsOptionsFlow(OptionsFlow, GoogleMapsFlow):
         self, _: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Finish the flow."""
-        if self._update_cookies:
+        if self._get_new_cookies:
             await self._save_new_cookies()
 
         return self.async_create_entry(title="", data=self._options)

--- a/custom_components/google_maps/config_flow.py
+++ b/custom_components/google_maps/config_flow.py
@@ -366,7 +366,6 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
 
     VERSION = 3
 
-    _update_entry: GMConfigEntry | None = None
     _get_new_cookies = True
 
     @staticmethod
@@ -374,6 +373,19 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry: ConfigEntry) -> GoogleMapsOptionsFlow:
         """Get the options flow for this handler."""
         return GoogleMapsOptionsFlow()
+
+    # https://developers.home-assistant.io/blog/2024/10/21/reauth-reconfigure-helpers/
+    # says _get_reauth_entry & _get_reconfigure_entry should be called in each step it
+    # is needed, and specifically that the result should NOT be "cached" in a class
+    # instance variable.
+    @property
+    def _update_entry(self) -> GMConfigEntry | None:
+        """Return config entry associated with flow (i.e., for reauth & reconfigure)."""
+        if self.source == SOURCE_REAUTH:
+            return self._get_reauth_entry()
+        if self.source == SOURCE_RECONFIGURE:
+            return self._get_reconfigure_entry()
+        return None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -383,12 +395,10 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
 
     async def async_step_reauth(self, data: Mapping[str, Any]) -> ConfigFlowResult:
         """Start reauthorization flow."""
-        self._update_entry = self._get_reauth_entry()
         return await self.async_step_username()
 
     async def async_step_reconfigure(self, data: Mapping[str, Any]) -> ConfigFlowResult:
         """Start reconfiguration flow."""
-        self._update_entry = self._get_reconfigure_entry()
         return await self.async_step_username()
 
     async def async_step_username(
@@ -398,6 +408,8 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
         errors = {}
         username: str | None
 
+        # Keep local copy for duration of step.
+        update_entry = self._update_entry
         if user_input is not None:
             username = cast(str, user_input[CONF_USERNAME])
             # Set unique ID to username and see if any existing config entries are
@@ -408,9 +420,9 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
             # updated. To put that another way, if the username is being changed, then
             # it can't be already in use by another config, or if it's not being
             # being changed, then the entry using it must be the one being updated.
-            if self._update_entry:
-                if not entry_w_username or entry_w_username is self._update_entry:
-                    self._init_flow_params(username, self._update_entry.options)
+            if update_entry:
+                if not entry_w_username or entry_w_username is update_entry:
+                    self._init_flow_params(username, update_entry.options)
                     return await self.async_step_check_cookies()
             # If creating a new entry, then no other existing entry can be using the
             # same username.
@@ -418,8 +430,8 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
                 self._init_flow_params(username, {})
                 return await self.async_step_get_cookies()
             errors[CONF_USERNAME] = "already_configured"
-        elif self._update_entry:
-            username = self._update_entry.unique_id
+        elif update_entry:
+            username = update_entry.unique_id
             assert username
         else:
             username = None
@@ -450,8 +462,10 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
             self._get_new_cookies = False
             return await self.async_step_done()
 
-        assert self._update_entry
-        file_ok = await self._existing_cookies_file_ok(self._update_entry)
+        # Keep local copy for duration of step.
+        update_entry = self._update_entry
+        assert update_entry
+        file_ok = await self._existing_cookies_file_ok(update_entry)
         data_schema = vol.Schema(
             {vol.Required(_CONF_UPDATE_COOKIES): BooleanSelector()}
         )
@@ -477,10 +491,12 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
         if self._get_new_cookies:
             await self._save_new_cookies()
 
-        if self._update_entry:
+        # Keep local copy for duration of step.
+        update_entry = self._update_entry
+        if update_entry:
             assert self.unique_id == self._username
             self.hass.config_entries.async_update_entry(
-                self._update_entry,
+                update_entry,
                 options=self._options,
                 title=self._username,
                 unique_id=self.unique_id,

--- a/custom_components/google_maps/config_flow.py
+++ b/custom_components/google_maps/config_flow.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 from abc import abstractmethod
 from asyncio import Lock
 from collections.abc import Mapping
+from copy import deepcopy
 from datetime import datetime
 import logging
 from os import PathLike
 from pathlib import Path
 from typing import Any, cast
 
+from propcache.api import cached_property
 import voluptuous as vol
 
 from homeassistant.components.file_upload import process_uploaded_file
@@ -18,7 +20,7 @@ from homeassistant.config_entries import (
     ConfigEntryBaseFlow,
     ConfigFlow,
     ConfigFlowResult,
-    OptionsFlowWithConfigEntry,
+    OptionsFlow,
 )
 from homeassistant.const import CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import callback
@@ -65,17 +67,14 @@ _GMSERVICE_ERRORS = (InvalidCookies, InvalidCookiesFile, InvalidData, RequestFai
 class GoogleMapsFlow(ConfigEntryBaseFlow):
     """Google Maps flow mixin."""
 
+    options: dict[str, Any]
+
     _username: str
     _api: GMLocSharing
     _expiration: datetime | None
     _cf_path: Path | None = None
     # The following is only used in the reauth flow.
     _reauth_entry: GMConfigEntry | None = None
-
-    @property
-    @abstractmethod
-    def options(self) -> dict[str, Any]:
-        """Return mutable copy of options."""
 
     def _cookies_file_ok(self, cookies_file: str | PathLike) -> bool:
         """Determine if cookies in file are ok.
@@ -351,28 +350,30 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
 
     VERSION = 2
 
-    _options: dict[str, Any]
-
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> GoogleMapsOptionsFlow:
         """Get the options flow for this handler."""
         return GoogleMapsOptionsFlow(config_entry)
 
-    @property
-    def options(self) -> dict[str, Any]:
-        """Return mutable copy of options."""
-        return self._options
-
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Start user config flow."""
+        errors = {}
+
         if user_input is not None:
-            self._username = user_input[CONF_USERNAME]
-            self._api = GMLocSharing(self._username)
-            self._options = {}
-            return await self.async_step_cookies()
+            username = user_input[CONF_USERNAME]
+            # Make sure usernames (i.e., accounts) are unique.
+            if not any(
+                cfg.data[CONF_USERNAME] == username
+                for cfg in self.hass.config_entries.async_entries(DOMAIN)
+            ):
+                self._username = username
+                self._api = GMLocSharing(self._username)
+                self.options = {}
+                return await self.async_step_cookies()
+            errors[CONF_USERNAME] = "already_configured_account"
 
         data_schema = vol.Schema(
             {
@@ -382,7 +383,7 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(
-            step_id="user", data_schema=data_schema, last_step=False
+            step_id="user", data_schema=data_schema, errors=errors, last_step=False
         )
 
     async def async_step_reauth(self, data: Mapping[str, Any]) -> ConfigFlowResult:
@@ -393,7 +394,7 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
             self.context["entry_id"]
         )
         assert self._reauth_entry
-        self._options = dict(self._reauth_entry.options)
+        self.options = deepcopy(dict(self._reauth_entry.options))
         return await self.async_step_cookies()
 
     async def async_step_done(
@@ -422,12 +423,16 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
         return self.async_abort(reason="reauth_successful")
 
 
-class GoogleMapsOptionsFlow(OptionsFlowWithConfigEntry, GoogleMapsFlow):
+class GoogleMapsOptionsFlow(OptionsFlow, GoogleMapsFlow):
     """Google Maps options flow."""
 
     _update_cookies = False
 
-    @property
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize flow."""
+        self.options = deepcopy(dict(config_entry.options))
+
+    @cached_property
     def gm_config_entry(self) -> GMConfigEntry:
         """Return the config entry linked to the current options flow."""
         return cast(GMConfigEntry, super().config_entry)
@@ -448,7 +453,7 @@ class GoogleMapsOptionsFlow(OptionsFlowWithConfigEntry, GoogleMapsFlow):
         )
         self._api = GMLocSharing(self._username)
         if hasattr(self.gm_config_entry, "runtime_data"):
-            lock = self.gm_config_entry.runtime_data.cookie_lock
+            lock = self.gm_config_entry.runtime_data.coordinator.cookie_lock
         else:
             lock = Lock()
         async with lock:

--- a/custom_components/google_maps/config_flow.py
+++ b/custom_components/google_maps/config_flow.py
@@ -161,7 +161,7 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
 class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
     """Google Maps config flow."""
 
-    VERSION = 4
+    VERSION = 3
 
     _get_new_cookies = True
     _expiration: datetime | None
@@ -454,7 +454,7 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
         update_entry = self._update_entry
         if update_entry:
             assert self.unique_id == self._username
-            # TODO: Use async_update_data_and_reload...???
+            # TODO: Use async_update_reload_and_abort(..., reload_even_if_entry_is_unchanged=False)???
             self.hass.config_entries.async_update_entry(
                 update_entry,
                 data=self._data,

--- a/custom_components/google_maps/config_flow.py
+++ b/custom_components/google_maps/config_flow.py
@@ -70,71 +70,233 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
     """Google Maps flow mixin."""
 
     _username: str
-    _api: GMLocSharing
     _options: dict[str, Any]
 
+    def _init_gmflow(self, username: str, options: Mapping[str, Any]) -> None:
+        """Initialize GoogleMapsFlow."""
+        self._username = username
+        self._options = deepcopy(dict(options))
+
+    async def async_step_account_entity(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Determine if entity should be created for account."""
+        if user_input is not None:
+            self._options[CONF_CREATE_ACCT_ENTITY] = user_input[CONF_CREATE_ACCT_ENTITY]
+            return await self.async_step_max_gps_accuracy()
+
+        data_schema = vol.Schema(
+            {vol.Required(CONF_CREATE_ACCT_ENTITY): BooleanSelector()}
+        )
+        data_schema = self.add_suggested_values_to_schema(
+            data_schema,
+            {CONF_CREATE_ACCT_ENTITY: self._options.get(CONF_CREATE_ACCT_ENTITY, True)},
+        )
+        if doc := (await async_get_integration(self.hass, DOMAIN)).documentation:
+            doc = (
+                "[Missing Data for Account Tracker]"
+                f"({doc}#missing-data-for-account-tracker)"
+            )
+        else:
+            doc = "the integration's documentation"
+        return self.async_show_form(
+            step_id="account_entity",
+            data_schema=data_schema,
+            description_placeholders={"doc": doc, "username": self._username},
+            last_step=False,
+        )
+
+    async def async_step_max_gps_accuracy(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Get maximum GPS accuracy."""
+        if user_input is not None:
+            self._options[CONF_MAX_GPS_ACCURACY] = int(
+                user_input[CONF_MAX_GPS_ACCURACY]
+            )
+            return await self.async_step_update_period()
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_MAX_GPS_ACCURACY): NumberSelector(
+                    NumberSelectorConfig(min=0, mode=NumberSelectorMode.BOX)
+                ),
+            }
+        )
+        data_schema = self.add_suggested_values_to_schema(
+            data_schema,
+            {CONF_MAX_GPS_ACCURACY: self._options.get(CONF_MAX_GPS_ACCURACY, 1000)},
+        )
+        return self.async_show_form(
+            step_id="max_gps_accuracy", data_schema=data_schema, last_step=False
+        )
+
+    async def async_step_update_period(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Get update period."""
+        if user_input is not None:
+            self._options[CONF_SCAN_INTERVAL] = int(
+                cv.time_period_dict(user_input[CONF_SCAN_INTERVAL]).total_seconds()
+            )
+            return await self.async_step_done()
+
+        data_schema = vol.Schema({vol.Required(CONF_SCAN_INTERVAL): DurationSelector()})
+        default = self._options.get(CONF_SCAN_INTERVAL, DEF_SCAN_INTERVAL_SEC)
+        def_m, def_s = divmod(default, 60)
+        def_h, def_m = divmod(def_m, 60)
+        data_schema = self.add_suggested_values_to_schema(
+            data_schema,
+            {CONF_SCAN_INTERVAL: {"hours": def_h, "minutes": def_m, "seconds": def_s}},
+        )
+        return self.async_show_form(step_id="update_period", data_schema=data_schema)
+
+    @abstractmethod
+    async def async_step_done(
+        self, _: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Finish the user config or options flow."""
+
+
+class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
+    """Google Maps config flow."""
+
+    VERSION = 4
+
+    _get_new_cookies = True
     _expiration: datetime | None
+    _api: GMLocSharing
+    _data: dict[str, Any]
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry: ConfigEntry) -> GoogleMapsOptionsFlow:
+        """Get the options flow for this handler."""
+        return GoogleMapsOptionsFlow()
 
     @cached_property
     def _is_existing(self) -> bool:
         """Return if this is a config flow for an existing config entry."""
         return self.source in (SOURCE_REAUTH, SOURCE_RECONFIGURE)
 
-    def _init_flow_params(self, username: str, options: Mapping[str, Any]) -> None:
-        """Initialize flow parameters."""
-        self._username = username
+    # https://developers.home-assistant.io/blog/2024/10/21/reauth-reconfigure-helpers/
+    # says _get_reauth_entry & _get_reconfigure_entry should be called in each step it
+    # is needed, and specifically that the result should NOT be "cached" in a class
+    # instance variable.
+    @property
+    def _update_entry(self) -> GMConfigEntry | None:
+        """Return config entry associated with flow (i.e., for reauth & reconfigure)."""
+        if self.source == SOURCE_REAUTH:
+            return self._get_reauth_entry()
+        if self.source == SOURCE_RECONFIGURE:
+            return self._get_reconfigure_entry()
+        return None
+
+    def _init_gmcfgflow(
+        self, username: str, options: Mapping[str, Any], data: Mapping[str, Any]
+    ) -> None:
+        """Initialize GoogleMapsConfigFlow."""
+        self._init_gmflow(username, options)
         self._api = GMLocSharing(username)
-        self._options = deepcopy(dict(options))
+        self._data = deepcopy(dict(data))
 
-    def _cookies_file_ok(self, cookies_file: str | PathLike) -> bool:
-        """Determine if cookies in file are ok.
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Start user config flow."""
+        return await self.async_step_username()
 
-        Must be called in an executor.
-        """
-        try:
-            self._api.load_cookies(str(cookies_file))
-            self._expiration = self._api.cookies_expiration
-            self._api.get_new_data()
-        except _GMSERVICE_ERRORS as err:
-            _LOGGER.debug(
-                "Error while validating cookies file %s: %r", cookies_file, err
-            )
-            return False
-        return True
+    async def async_step_reauth(self, data: Mapping[str, Any]) -> ConfigFlowResult:
+        """Start reauthorization flow."""
+        return await self.async_step_username()
 
-    def _uploaded_cookies_ok(self, uploaded_file_id: str) -> bool:
-        """Determine if cookies in uploaded cookies file are ok.
+    async def async_step_reconfigure(self, data: Mapping[str, Any]) -> ConfigFlowResult:
+        """Start reconfiguration flow."""
+        return await self.async_step_username()
 
-        Must be called in an executor.
-        """
-        with process_uploaded_file(self.hass, uploaded_file_id) as cf_path:
-            return self._cookies_file_ok(cf_path)
+    async def async_step_username(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Get username."""
+        errors = {}
+        username: str | None
 
-    def _save_cookies(self, cookies_file: str) -> None:
-        """Save cookies.
-
-        Must be called in an executor.
-        """
-        cf_path = cookies_file_path(self.hass, cookies_file)
-        cf_path.parent.mkdir(exist_ok=True)
-        self._api.save_cookies(str(cf_path))
-
-    async def _existing_cookies_file_ok(self, entry: GMConfigEntry) -> bool:
-        """Return if existing cookies file is ok."""
-        if hasattr(entry, "runtime_data"):
-            lock = entry.runtime_data.coordinator.cookie_lock
+        # Keep local copy for duration of step.
+        update_entry = self._update_entry
+        if user_input is not None:
+            username = cast(str, user_input[CONF_USERNAME])
+            # Set unique ID to username and see if any existing config entries are
+            # already using that username.
+            entry_w_username = await self.async_set_unique_id(username)
+            # If entry is being updated (reauth or reconfig), then the username must not
+            # be in use by another config entry, or if it is, it must be the entry being
+            # updated. To put that another way, if the username is being changed, then
+            # it can't be already in use by another config, or if it's not being
+            # being changed, then the entry using it must be the one being updated.
+            if update_entry:
+                if not entry_w_username or entry_w_username is update_entry:
+                    self._init_gmcfgflow(
+                        username, update_entry.options, update_entry.data
+                    )
+                    return await self.async_step_check_cookies()
+            # If creating a new entry, then no other existing entry can be using the
+            # same username.
+            elif not entry_w_username:
+                self._init_gmcfgflow(username, {}, {})
+                return await self.async_step_get_cookies()
+            errors[CONF_USERNAME] = "already_configured"
+        elif update_entry:
+            username = update_entry.unique_id
+            assert username
         else:
-            lock = Lock()
-        async with lock:
-            return await self.hass.async_add_executor_job(
-                self._cookies_file_ok,
-                cookies_file_path(self.hass, entry.options[CONF_COOKIES_FILE]),
-            )
+            username = None
 
-    async def _save_new_cookies(self) -> None:
-        """Save new cookies to newly named file."""
-        self._options[CONF_COOKIES_FILE] = cookies_file = random_uuid_hex()
-        await self.hass.async_add_executor_job(self._save_cookies, cookies_file)
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_USERNAME): TextSelector(
+                    TextSelectorConfig(type=TextSelectorType.EMAIL)
+                )
+            }
+        )
+        if username:
+            data_schema = self.add_suggested_values_to_schema(
+                data_schema, {CONF_USERNAME: username}
+            )
+        return self.async_show_form(
+            step_id="username", data_schema=data_schema, errors=errors, last_step=False
+        )
+
+    async def async_step_check_cookies(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Get username."""
+
+        if user_input is not None:
+            if user_input[_CONF_UPDATE_COOKIES]:
+                return await self.async_step_get_cookies()
+            self._get_new_cookies = False
+            return await self.async_step_done()
+
+        # Keep local copy for duration of step.
+        update_entry = self._update_entry
+        assert update_entry
+        file_ok = await self._existing_cookies_file_ok(update_entry)
+        data_schema = vol.Schema(
+            {vol.Required(_CONF_UPDATE_COOKIES): BooleanSelector()}
+        )
+        data_schema = self.add_suggested_values_to_schema(
+            data_schema,
+            {_CONF_UPDATE_COOKIES: not file_ok or expiring_soon(self._expiration)},
+        )
+        return self.async_show_form(
+            step_id="check_cookies",
+            data_schema=data_schema,
+            description_placeholders={
+                "username": self._username,
+                "expiration": exp_2_str(self._expiration),
+            },
+            last_step=False,
+        )
 
     async def async_step_get_cookies(
         self, user_input: dict[str, Any] | None = None
@@ -280,209 +442,6 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
             },
         )
 
-    async def async_step_account_entity(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Determine if entity should be created for account."""
-        if user_input is not None:
-            self._options[CONF_CREATE_ACCT_ENTITY] = user_input[CONF_CREATE_ACCT_ENTITY]
-            return await self.async_step_max_gps_accuracy()
-
-        data_schema = vol.Schema(
-            {vol.Required(CONF_CREATE_ACCT_ENTITY): BooleanSelector()}
-        )
-        data_schema = self.add_suggested_values_to_schema(
-            data_schema,
-            {CONF_CREATE_ACCT_ENTITY: self._options.get(CONF_CREATE_ACCT_ENTITY, True)},
-        )
-        if doc := (await async_get_integration(self.hass, DOMAIN)).documentation:
-            doc = (
-                "[Missing Data for Account Tracker]"
-                f"({doc}#missing-data-for-account-tracker)"
-            )
-        else:
-            doc = "the integration's documentation"
-        return self.async_show_form(
-            step_id="account_entity",
-            data_schema=data_schema,
-            description_placeholders={"doc": doc, "username": self._username},
-            last_step=False,
-        )
-
-    async def async_step_max_gps_accuracy(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Get maximum GPS accuracy."""
-        if user_input is not None:
-            self._options[CONF_MAX_GPS_ACCURACY] = int(
-                user_input[CONF_MAX_GPS_ACCURACY]
-            )
-            return await self.async_step_update_period()
-
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_MAX_GPS_ACCURACY): NumberSelector(
-                    NumberSelectorConfig(min=0, mode=NumberSelectorMode.BOX)
-                ),
-            }
-        )
-        data_schema = self.add_suggested_values_to_schema(
-            data_schema,
-            {CONF_MAX_GPS_ACCURACY: self._options.get(CONF_MAX_GPS_ACCURACY, 1000)},
-        )
-        return self.async_show_form(
-            step_id="max_gps_accuracy", data_schema=data_schema, last_step=False
-        )
-
-    async def async_step_update_period(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Get update period."""
-        if user_input is not None:
-            self._options[CONF_SCAN_INTERVAL] = int(
-                cv.time_period_dict(user_input[CONF_SCAN_INTERVAL]).total_seconds()
-            )
-            return await self.async_step_done()
-
-        data_schema = vol.Schema({vol.Required(CONF_SCAN_INTERVAL): DurationSelector()})
-        default = self._options.get(CONF_SCAN_INTERVAL, DEF_SCAN_INTERVAL_SEC)
-        def_m, def_s = divmod(default, 60)
-        def_h, def_m = divmod(def_m, 60)
-        data_schema = self.add_suggested_values_to_schema(
-            data_schema,
-            {CONF_SCAN_INTERVAL: {"hours": def_h, "minutes": def_m, "seconds": def_s}},
-        )
-        return self.async_show_form(step_id="update_period", data_schema=data_schema)
-
-    @abstractmethod
-    async def async_step_done(
-        self, _: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Finish the user config or options flow."""
-
-
-class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
-    """Google Maps config flow."""
-
-    VERSION = 3
-
-    _get_new_cookies = True
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry: ConfigEntry) -> GoogleMapsOptionsFlow:
-        """Get the options flow for this handler."""
-        return GoogleMapsOptionsFlow()
-
-    # https://developers.home-assistant.io/blog/2024/10/21/reauth-reconfigure-helpers/
-    # says _get_reauth_entry & _get_reconfigure_entry should be called in each step it
-    # is needed, and specifically that the result should NOT be "cached" in a class
-    # instance variable.
-    @property
-    def _update_entry(self) -> GMConfigEntry | None:
-        """Return config entry associated with flow (i.e., for reauth & reconfigure)."""
-        if self.source == SOURCE_REAUTH:
-            return self._get_reauth_entry()
-        if self.source == SOURCE_RECONFIGURE:
-            return self._get_reconfigure_entry()
-        return None
-
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Start user config flow."""
-        return await self.async_step_username()
-
-    async def async_step_reauth(self, data: Mapping[str, Any]) -> ConfigFlowResult:
-        """Start reauthorization flow."""
-        return await self.async_step_username()
-
-    async def async_step_reconfigure(self, data: Mapping[str, Any]) -> ConfigFlowResult:
-        """Start reconfiguration flow."""
-        return await self.async_step_username()
-
-    async def async_step_username(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Get username."""
-        errors = {}
-        username: str | None
-
-        # Keep local copy for duration of step.
-        update_entry = self._update_entry
-        if user_input is not None:
-            username = cast(str, user_input[CONF_USERNAME])
-            # Set unique ID to username and see if any existing config entries are
-            # already using that username.
-            entry_w_username = await self.async_set_unique_id(username)
-            # If entry is being updated (reauth or reconfig), then the username must not
-            # be in use by another config entry, or if it is, it must be the entry being
-            # updated. To put that another way, if the username is being changed, then
-            # it can't be already in use by another config, or if it's not being
-            # being changed, then the entry using it must be the one being updated.
-            if update_entry:
-                if not entry_w_username or entry_w_username is update_entry:
-                    self._init_flow_params(username, update_entry.options)
-                    return await self.async_step_check_cookies()
-            # If creating a new entry, then no other existing entry can be using the
-            # same username.
-            elif not entry_w_username:
-                self._init_flow_params(username, {})
-                return await self.async_step_get_cookies()
-            errors[CONF_USERNAME] = "already_configured"
-        elif update_entry:
-            username = update_entry.unique_id
-            assert username
-        else:
-            username = None
-
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): TextSelector(
-                    TextSelectorConfig(type=TextSelectorType.EMAIL)
-                )
-            }
-        )
-        if username:
-            data_schema = self.add_suggested_values_to_schema(
-                data_schema, {CONF_USERNAME: username}
-            )
-        return self.async_show_form(
-            step_id="username", data_schema=data_schema, errors=errors, last_step=False
-        )
-
-    async def async_step_check_cookies(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Get username."""
-
-        if user_input is not None:
-            if user_input[_CONF_UPDATE_COOKIES]:
-                return await self.async_step_get_cookies()
-            self._get_new_cookies = False
-            return await self.async_step_done()
-
-        # Keep local copy for duration of step.
-        update_entry = self._update_entry
-        assert update_entry
-        file_ok = await self._existing_cookies_file_ok(update_entry)
-        data_schema = vol.Schema(
-            {vol.Required(_CONF_UPDATE_COOKIES): BooleanSelector()}
-        )
-        data_schema = self.add_suggested_values_to_schema(
-            data_schema,
-            {_CONF_UPDATE_COOKIES: not file_ok or expiring_soon(self._expiration)},
-        )
-        return self.async_show_form(
-            step_id="check_cookies",
-            data_schema=data_schema,
-            description_placeholders={
-                "username": self._username,
-                "expiration": exp_2_str(self._expiration),
-            },
-            last_step=False,
-        )
-
     async def async_step_done(
         self, _: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -495,8 +454,10 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
         update_entry = self._update_entry
         if update_entry:
             assert self.unique_id == self._username
+            # TODO: Use async_update_data_and_reload...???
             self.hass.config_entries.async_update_entry(
                 update_entry,
+                data=self._data,
                 options=self._options,
                 title=self._username,
                 unique_id=self.unique_id,
@@ -509,54 +470,74 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
             return self.async_abort(reason=f"{self.source}_successful")
 
         return self.async_create_entry(
-            title=self._username,
-            data={},
-            options=self._options,
+            title=self._username, data=self._data, options=self._options
         )
+
+    async def _existing_cookies_file_ok(self, entry: GMConfigEntry) -> bool:
+        """Return if existing cookies file is ok."""
+        if hasattr(entry, "runtime_data"):
+            lock = entry.runtime_data.coordinator.cookie_lock
+        else:
+            lock = Lock()
+        async with lock:
+            return await self.hass.async_add_executor_job(
+                self._cookies_file_ok,
+                cookies_file_path(self.hass, entry.data[CONF_COOKIES_FILE]),
+            )
+
+    async def _save_new_cookies(self) -> None:
+        """Save new cookies to newly named file."""
+        self._data[CONF_COOKIES_FILE] = cookies_file = random_uuid_hex()
+        await self.hass.async_add_executor_job(self._save_cookies, cookies_file)
+
+    def _cookies_file_ok(self, cookies_file: str | PathLike) -> bool:
+        """Determine if cookies in file are ok.
+
+        Must be called in an executor.
+        """
+        try:
+            self._api.load_cookies(str(cookies_file))
+            self._expiration = self._api.cookies_expiration
+            self._api.get_new_data()
+        except _GMSERVICE_ERRORS as err:
+            _LOGGER.debug(
+                "Error while validating cookies file %s: %r", cookies_file, err
+            )
+            return False
+        return True
+
+    def _uploaded_cookies_ok(self, uploaded_file_id: str) -> bool:
+        """Determine if cookies in uploaded cookies file are ok.
+
+        Must be called in an executor.
+        """
+        with process_uploaded_file(self.hass, uploaded_file_id) as cf_path:
+            return self._cookies_file_ok(cf_path)
+
+    def _save_cookies(self, cookies_file: str) -> None:
+        """Save cookies.
+
+        Must be called in an executor.
+        """
+        cf_path = cookies_file_path(self.hass, cookies_file)
+        cf_path.parent.mkdir(exist_ok=True)
+        self._api.save_cookies(str(cf_path))
 
 
 class GoogleMapsOptionsFlow(OptionsFlow, GoogleMapsFlow):
     """Google Maps options flow."""
 
-    _get_new_cookies = False
-
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Start options flow."""
-        if user_input is not None:
-            if user_input[_CONF_UPDATE_COOKIES]:
-                self._get_new_cookies = True
-                return await self.async_step_get_cookies()
-            return await self.async_step_account_entity()
-
         username = self.config_entry.unique_id
         assert username
-        self._init_flow_params(username, self.config_entry.options)
-
-        file_ok = await self._existing_cookies_file_ok(self.config_entry)
-        data_schema = vol.Schema(
-            {vol.Required(_CONF_UPDATE_COOKIES): BooleanSelector()}
-        )
-        data_schema = self.add_suggested_values_to_schema(
-            data_schema,
-            {_CONF_UPDATE_COOKIES: not file_ok or expiring_soon(self._expiration)},
-        )
-        return self.async_show_form(
-            step_id="init",
-            data_schema=data_schema,
-            description_placeholders={
-                "username": self._username,
-                "expiration": exp_2_str(self._expiration),
-            },
-            last_step=False,
-        )
+        self._init_gmflow(username, self.config_entry.options)
+        return await self.async_step_account_entity()
 
     async def async_step_done(
         self, _: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Finish the flow."""
-        if self._get_new_cookies:
-            await self._save_new_cookies()
-
         return self.async_create_entry(title="", data=self._options)

--- a/custom_components/google_maps/config_flow.py
+++ b/custom_components/google_maps/config_flow.py
@@ -16,6 +16,7 @@ import voluptuous as vol
 
 from homeassistant.components.file_upload import process_uploaded_file
 from homeassistant.config_entries import (
+    SOURCE_REAUTH,
     ConfigEntry,
     ConfigEntryBaseFlow,
     ConfigFlow,
@@ -67,14 +68,24 @@ _GMSERVICE_ERRORS = (InvalidCookies, InvalidCookiesFile, InvalidData, RequestFai
 class GoogleMapsFlow(ConfigEntryBaseFlow):
     """Google Maps flow mixin."""
 
-    options: dict[str, Any]
-
     _username: str
     _api: GMLocSharing
+    _options: dict[str, Any]
+
     _expiration: datetime | None
-    _cf_path: Path | None = None
-    # The following is only used in the reauth flow.
-    _reauth_entry: GMConfigEntry | None = None
+
+    @cached_property
+    def _is_reauth(self) -> bool:
+        """Return if this is a re-authentication config flow."""
+        return self.source == SOURCE_REAUTH
+
+    def _init_flow_params(
+        self, username: str, options: Mapping[str, Any] | None = None
+    ) -> None:
+        """Initialize flow parameters."""
+        self._username = username
+        self._api = GMLocSharing(username)
+        self._options = deepcopy(dict(options or {}))
 
     def _cookies_file_ok(self, cookies_file: str | PathLike) -> bool:
         """Determine if cookies in file are ok.
@@ -111,7 +122,7 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
 
     async def _save_new_cookies(self) -> None:
         """Save new cookies to newly named file."""
-        self.options[CONF_COOKIES_FILE] = cookies_file = random_uuid_hex()
+        self._options[CONF_COOKIES_FILE] = cookies_file = random_uuid_hex()
         await self.hass.async_add_executor_job(self._save_cookies, cookies_file)
 
     async def async_step_cookies(
@@ -121,17 +132,15 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
         if user_input is not None:
             if not user_input[_CONF_USE_EXISTING_COOKIES]:
                 return await self.async_step_get_cookies_procedure_menu()
-            if self._reauth_entry:
-                return await self.async_step_reauth_done()
+            if self._is_reauth:
+                return await self.async_step_done()
             return await self.async_step_account_entity()
 
-        self._cf_path = old_cookies_file_path(self.hass, self._username)
-        if not await self.hass.async_add_executor_job(self._cf_path.is_file):
+        cf_path = old_cookies_file_path(self.hass, self._username)
+        if not await self.hass.async_add_executor_job(cf_path.is_file):
             return await self.async_step_get_cookies_procedure_menu()
-        if not await self.hass.async_add_executor_job(
-            self._cookies_file_ok, self._cf_path
-        ):
-            return await self.async_step_old_cookies_invalid()
+        if not await self.hass.async_add_executor_job(self._cookies_file_ok, cf_path):
+            return await self.async_step_old_cookies_invalid(cf_path=cf_path)
 
         data_schema = vol.Schema(
             {vol.Required(_CONF_USE_EXISTING_COOKIES): BooleanSelector()}
@@ -144,25 +153,25 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
             data_schema=data_schema,
             description_placeholders={
                 "username": self._username,
-                "cookies_file": str(self._cf_path.name),
+                "cookies_file": str(cf_path.name),
                 "expiration": exp_2_str(self._expiration),
             },
             last_step=False,
         )
 
     async def async_step_old_cookies_invalid(
-        self, user_input: dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None, cf_path: Path | None = None
     ) -> ConfigFlowResult:
         """Upload a cookies file."""
         if user_input is not None:
             return await self.async_step_get_cookies_procedure_menu()
 
-        assert self._cf_path
+        assert cf_path
         return self.async_show_form(
             step_id="old_cookies_invalid",
             description_placeholders={
                 "username": self._username,
-                "cookies_file": str(self._cf_path.name),
+                "cookies_file": str(cf_path.name),
             },
             last_step=False,
         )
@@ -248,7 +257,7 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Use uploaded cookie file or try again."""
         menu_options = [
-            "reauth_done" if self._reauth_entry else "account_entity",
+            "reauth_done" if self._is_reauth else "account_entity",
             "get_cookies_procedure_menu",
         ]
         return self.async_show_menu(
@@ -265,7 +274,7 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Determine if entity should be created for account."""
         if user_input is not None:
-            self.options[CONF_CREATE_ACCT_ENTITY] = user_input[CONF_CREATE_ACCT_ENTITY]
+            self._options[CONF_CREATE_ACCT_ENTITY] = user_input[CONF_CREATE_ACCT_ENTITY]
             return await self.async_step_max_gps_accuracy()
 
         data_schema = vol.Schema(
@@ -273,7 +282,7 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
         )
         data_schema = self.add_suggested_values_to_schema(
             data_schema,
-            {CONF_CREATE_ACCT_ENTITY: self.options.get(CONF_CREATE_ACCT_ENTITY, True)},
+            {CONF_CREATE_ACCT_ENTITY: self._options.get(CONF_CREATE_ACCT_ENTITY, True)},
         )
         if doc := (await async_get_integration(self.hass, DOMAIN)).documentation:
             doc = (
@@ -294,7 +303,9 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Get maximum GPS accuracy."""
         if user_input is not None:
-            self.options[CONF_MAX_GPS_ACCURACY] = int(user_input[CONF_MAX_GPS_ACCURACY])
+            self._options[CONF_MAX_GPS_ACCURACY] = int(
+                user_input[CONF_MAX_GPS_ACCURACY]
+            )
             return await self.async_step_update_period()
 
         data_schema = vol.Schema(
@@ -306,7 +317,7 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
         )
         data_schema = self.add_suggested_values_to_schema(
             data_schema,
-            {CONF_MAX_GPS_ACCURACY: self.options.get(CONF_MAX_GPS_ACCURACY, 1000)},
+            {CONF_MAX_GPS_ACCURACY: self._options.get(CONF_MAX_GPS_ACCURACY, 1000)},
         )
         return self.async_show_form(
             step_id="max_gps_accuracy", data_schema=data_schema, last_step=False
@@ -317,13 +328,13 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Get update period."""
         if user_input is not None:
-            self.options[CONF_SCAN_INTERVAL] = int(
+            self._options[CONF_SCAN_INTERVAL] = int(
                 cv.time_period_dict(user_input[CONF_SCAN_INTERVAL]).total_seconds()
             )
             return await self.async_step_done()
 
         data_schema = vol.Schema({vol.Required(CONF_SCAN_INTERVAL): DurationSelector()})
-        default = self.options.get(CONF_SCAN_INTERVAL, DEF_SCAN_INTERVAL_SEC)
+        default = self._options.get(CONF_SCAN_INTERVAL, DEF_SCAN_INTERVAL_SEC)
         def_m, def_s = divmod(default, 60)
         def_h, def_m = divmod(def_m, 60)
         data_schema = self.add_suggested_values_to_schema(
@@ -338,42 +349,40 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
     ) -> ConfigFlowResult:
         """Finish the user config or options flow."""
 
-    async def async_step_reauth_done(
-        self, _: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Finish the reauthorization flow."""
-        raise NotImplementedError
-
 
 class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
     """Google Maps config flow."""
 
-    VERSION = 2
+    VERSION = 3
 
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> GoogleMapsOptionsFlow:
         """Get the options flow for this handler."""
-        return GoogleMapsOptionsFlow(config_entry)
+        return GoogleMapsOptionsFlow()
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Start user config flow."""
-        errors = {}
+        return await self.async_step_username()
 
+    async def async_step_reauth(self, data: Mapping[str, Any]) -> ConfigFlowResult:
+        """Start reauthorization flow."""
+        assert self.unique_id
+        self._init_flow_params(self.unique_id, self._get_reauth_entry().options)
+        return await self.async_step_cookies()
+
+    async def async_step_username(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Get username."""
         if user_input is not None:
             username = user_input[CONF_USERNAME]
-            # Make sure usernames (i.e., accounts) are unique.
-            if not any(
-                cfg.data[CONF_USERNAME] == username
-                for cfg in self.hass.config_entries.async_entries(DOMAIN)
-            ):
-                self._username = username
-                self._api = GMLocSharing(self._username)
-                self.options = {}
-                return await self.async_step_cookies()
-            errors[CONF_USERNAME] = "already_configured_account"
+            await self.async_set_unique_id(username)
+            self._abort_if_unique_id_configured()
+            self._init_flow_params(username)
+            return await self.async_step_cookies()
 
         data_schema = vol.Schema(
             {
@@ -383,59 +392,34 @@ class GoogleMapsConfigFlow(ConfigFlow, GoogleMapsFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(
-            step_id="user", data_schema=data_schema, errors=errors, last_step=False
+            step_id="username", data_schema=data_schema, last_step=False
         )
-
-    async def async_step_reauth(self, data: Mapping[str, Any]) -> ConfigFlowResult:
-        """Start reauthorization flow."""
-        self._username = data[CONF_USERNAME]
-        self._api = GMLocSharing(self._username)
-        self._reauth_entry = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
-        )
-        assert self._reauth_entry
-        self.options = deepcopy(dict(self._reauth_entry.options))
-        return await self.async_step_cookies()
 
     async def async_step_done(
         self, _: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Finish the user config flow."""
+        """Finish the config flow."""
         # Save cookies.
         await self._save_new_cookies()
+
+        if self._is_reauth:
+            self.hass.config_entries.async_update_entry(
+                self._get_reauth_entry(), options=self._options
+            )
+            _LOGGER.debug("Reauthorization successful")
+            return self.async_abort(reason="reauth_successful")
+
         return self.async_create_entry(
             title=self._username,
-            data={CONF_USERNAME: self._username},
-            options=self.options,
+            data={},
+            options=self._options,
         )
-
-    async def async_step_reauth_done(
-        self, _: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Finish the reauthorization flow."""
-        # Save cookies.
-        await self._save_new_cookies()
-        assert self._reauth_entry
-        self.hass.config_entries.async_update_entry(
-            self._reauth_entry, options=self.options
-        )
-        _LOGGER.debug("Reauthorization successful")
-        return self.async_abort(reason="reauth_successful")
 
 
 class GoogleMapsOptionsFlow(OptionsFlow, GoogleMapsFlow):
     """Google Maps options flow."""
 
     _update_cookies = False
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize flow."""
-        self.options = deepcopy(dict(config_entry.options))
-
-    @cached_property
-    def gm_config_entry(self) -> GMConfigEntry:
-        """Return the config entry linked to the current options flow."""
-        return cast(GMConfigEntry, super().config_entry)
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -447,18 +431,21 @@ class GoogleMapsOptionsFlow(OptionsFlow, GoogleMapsFlow):
                 return await self.async_step_cookies()
             return await self.async_step_account_entity()
 
-        self._username = self.gm_config_entry.data[CONF_USERNAME]
-        cf_path = cookies_file_path(
-            self.hass, self.gm_config_entry.options[CONF_COOKIES_FILE]
-        )
-        self._api = GMLocSharing(self._username)
-        if hasattr(self.gm_config_entry, "runtime_data"):
-            lock = self.gm_config_entry.runtime_data.coordinator.cookie_lock
+        username = self.config_entry.unique_id
+        assert username
+        self._init_flow_params(username, self.config_entry.options)
+        if hasattr(self.config_entry, "runtime_data"):
+            lock = cast(
+                GMConfigEntry, self.config_entry
+            ).runtime_data.coordinator.cookie_lock
         else:
             lock = Lock()
         async with lock:
             file_ok = await self.hass.async_add_executor_job(
-                self._cookies_file_ok, cf_path
+                self._cookies_file_ok,
+                cookies_file_path(
+                    self.hass, self.config_entry.options[CONF_COOKIES_FILE]
+                ),
             )
         data_schema = vol.Schema(
             {vol.Required(_CONF_UPDATE_COOKIES): BooleanSelector()}
@@ -484,4 +471,4 @@ class GoogleMapsOptionsFlow(OptionsFlow, GoogleMapsFlow):
         if self._update_cookies:
             await self._save_new_cookies()
 
-        return self.async_create_entry(title="", data=self.options)
+        return self.async_create_entry(title="", data=self._options)

--- a/custom_components/google_maps/const.py
+++ b/custom_components/google_maps/const.py
@@ -5,7 +5,6 @@ from homeassistant.const import ATTR_ENTITY_PICTURE
 
 DOMAIN = "google_maps"
 ATTRIBUTION = "Data from Google Maps"
-NAME_PREFIX = "Google Maps"
 
 CREDENTIALS_FILE = ".google_maps_location_sharing.cookies"
 
@@ -14,7 +13,6 @@ DEF_SCAN_INTERVAL = timedelta(seconds=DEF_SCAN_INTERVAL_SEC)
 COOKIE_WARNING_PERIOD = timedelta(weeks=4)
 
 ATTR_ADDRESS = "address"
-ATTR_FULL_NAME = "full_name"
 ATTR_LAST_SEEN = "last_seen"
 ATTR_NICKNAME = "nickname"
 

--- a/custom_components/google_maps/const.py
+++ b/custom_components/google_maps/const.py
@@ -10,6 +10,7 @@ CREDENTIALS_FILE = ".google_maps_location_sharing.cookies"
 
 DEF_SCAN_INTERVAL_SEC = 60
 DEF_SCAN_INTERVAL = timedelta(seconds=DEF_SCAN_INTERVAL_SEC)
+MISSING_DATA_GRACE_PERIOD = 3 * 60
 COOKIE_WARNING_PERIOD = timedelta(weeks=4)
 
 ATTR_ADDRESS = "address"

--- a/custom_components/google_maps/coordinator.py
+++ b/custom_components/google_maps/coordinator.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
-from pathlib import Path
 from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
@@ -80,17 +79,11 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
         cur_cookies_file = str(
             cookies_file_path(self.hass, self.config_entry.data[CONF_COOKIES_FILE])
         )
-        # Has cookies file name changed, e.g., due to reauth or user reconfiguration?
-        # If not, save cookies to existing file. If so, delete file that was being used
-        # because there's a new one to be used after reload/restart.
+        # Save cookies if cookies file name has not changed (e.g., due to reauth or user
+        # reconfiguration) and cookies themselves have changed.
         if cur_cookies_file == self._cookies_file:
             await self._save_cookies_if_changed(shutting_down=True)
-        else:
-            # TODO: Is this necessary, or even wise, since config entry unload & remove
-            #       do the same thing???
-            await self.hass.async_add_executor_job(Path(self._cookies_file).unlink)
-        # TODO: Does close do I/O and need to be run in an executor???
-        self._api.close()
+        self.hass.async_add_executor_job(self._api.close)
 
     def _unsub_all(self) -> None:
         """Run removers."""

--- a/custom_components/google_maps/coordinator.py
+++ b/custom_components/google_maps/coordinator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from asyncio import Lock
 from collections.abc import Callable
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 from pathlib import Path
@@ -15,12 +16,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.helpers.issue_registry import (
-    IssueSeverity,
-    async_create_issue,
-    async_delete_issue,
-)
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -67,11 +64,14 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
             EVENT_HOMEASSISTANT_FINAL_WRITE, self._save_cookies_if_changed
         )
 
-        scan_interval = timedelta(seconds=entry.options[CONF_SCAN_INTERVAL])
-        super().__init__(hass, _LOGGER, name=entry.title, update_interval=scan_interval)
-        # always_update added in 2023.9.0b0.
-        if hasattr(self, "always_update"):
-            self.always_update = False
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=entry.title,
+            update_interval=timedelta(seconds=entry.options[CONF_SCAN_INTERVAL]),
+            always_update=False,
+        )
 
     async def async_shutdown(self) -> None:
         """Cancel listeners, save cookies & close API."""
@@ -123,7 +123,9 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
             except (RequestFailed, InvalidData) as err:
                 raise UpdateFailed(f"{err.__class__.__name__}: {err}") from err
 
-        await self.hass.async_create_task(self._save_cookies_if_changed())
+        await self.config_entry.async_create_task(
+            self.hass, self._save_cookies_if_changed(), "Save cookies if changed"
+        )
         return {
             UniqueID(person.id): PersonData.from_person(person) for person in people
         }
@@ -162,7 +164,7 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
         if expiring_soon(cookies_expiration):
             self._create_issue()
         else:
-            async_delete_issue(self.hass, DOMAIN, self._cid)
+            ir.async_delete_issue(self.hass, DOMAIN, self._cid)
             if cookies_expiration and not shutting_down:
                 self._unsub_expiration()
                 self._unsub_exp = async_track_point_in_utc_time(
@@ -174,13 +176,12 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
     @callback
     def _create_issue(self, _utcnow: datetime | None = None) -> None:
         """Create repair issue for cookies which are expiring soon."""
-        async_create_issue(
+        ir.async_create_issue(
             self.hass,
             DOMAIN,
             self._cid,
             is_fixable=False,
-            is_persistent=False,
-            severity=IssueSeverity.WARNING,
+            severity=ir.IssueSeverity.WARNING,
             translation_key="expiring_soon",
             translation_placeholders={
                 "entry_id": self._cid,
@@ -189,4 +190,12 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
         )
 
 
-type GMConfigEntry = ConfigEntry[GMDataUpdateCoordinator]
+@dataclass
+class GMConfigEntryParams:
+    """Google Maps Config Entry Parameters."""
+
+    coordinator: GMDataUpdateCoordinator
+    setup_with_acct_entity: bool
+
+
+GMConfigEntry = ConfigEntry[GMConfigEntryParams]

--- a/custom_components/google_maps/coordinator.py
+++ b/custom_components/google_maps/coordinator.py
@@ -54,9 +54,7 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize coordinator."""
-        self._cookies_file = str(
-            cookies_file_path(hass, entry.options[CONF_COOKIES_FILE])
-        )
+        self._cookies_file = str(cookies_file_path(hass, entry.data[CONF_COOKIES_FILE]))
         self._create_acct_entity = entry.options[CONF_CREATE_ACCT_ENTITY]
 
         # The account's username is used as the config entry's unique ID.
@@ -80,7 +78,7 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
         await super().async_shutdown()
         self._unsub_all()
         cur_cookies_file = str(
-            cookies_file_path(self.hass, self.config_entry.options[CONF_COOKIES_FILE])
+            cookies_file_path(self.hass, self.config_entry.data[CONF_COOKIES_FILE])
         )
         # Has cookies file name changed, e.g., due to reauth or user reconfiguration?
         # If not, save cookies to existing file. If so, delete file that was being used
@@ -88,7 +86,10 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
         if cur_cookies_file == self._cookies_file:
             await self._save_cookies_if_changed(shutting_down=True)
         else:
+            # TODO: Is this necessary, or even wise, since config entry unload & remove
+            #       do the same thing???
             await self.hass.async_add_executor_job(Path(self._cookies_file).unlink)
+        # TODO: Does close do I/O and need to be run in an executor???
         self._api.close()
 
     def _unsub_all(self) -> None:

--- a/custom_components/google_maps/coordinator.py
+++ b/custom_components/google_maps/coordinator.py
@@ -7,13 +7,10 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 from pathlib import Path
+from typing import cast
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_SCAN_INTERVAL,
-    CONF_USERNAME,
-    EVENT_HOMEASSISTANT_FINAL_WRITE,
-)
+from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_FINAL_WRITE
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
@@ -34,12 +31,17 @@ from .gm_loc_sharing import (
     InvalidData,
     RequestFailed,
 )
-from .helpers import ConfigID, PersonData, UniqueID, cookies_file_path, expiring_soon
+from .helpers import PersonData, UniqueID, cookies_file_path, expiring_soon
 
 _LOGGER = logging.getLogger(__name__)
 
 
 GMData = dict[UniqueID, PersonData]
+"""Google Maps data.
+
+Dictionary of unique ID -> PersonData.
+For "account entity", unique ID is the account's email address.
+"""
 
 
 class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
@@ -51,14 +53,13 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize coordinator."""
-        self._cid = ConfigID(entry.entry_id)
-        self._username = entry.data[CONF_USERNAME]
         self._cookies_file = str(
             cookies_file_path(hass, entry.options[CONF_COOKIES_FILE])
         )
         self._create_acct_entity = entry.options[CONF_CREATE_ACCT_ENTITY]
 
-        self._api = GMLocSharing(self._username)
+        # The account's username is used as the config entry's unique ID.
+        self._api = GMLocSharing(cast(str, entry.unique_id))
         self.cookie_lock = Lock()
         self._unsub_final_write = hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_FINAL_WRITE, self._save_cookies_if_changed
@@ -113,7 +114,10 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
             self._cookies_file_synced()
 
     async def _async_update_data(self) -> GMData:
-        """Fetch the latest data from the source."""
+        """Fetch the latest data from the source.
+
+        If creating "account entity", its unique ID will be the account's email address.
+        """
         async with self.cookie_lock:
             try:
                 await self.hass.async_add_executor_job(self._api.get_new_data)
@@ -164,7 +168,7 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
         if expiring_soon(cookies_expiration):
             self._create_issue()
         else:
-            ir.async_delete_issue(self.hass, DOMAIN, self._cid)
+            ir.async_delete_issue(self.hass, DOMAIN, self.config_entry.entry_id)
             if cookies_expiration and not shutting_down:
                 self._unsub_expiration()
                 self._unsub_exp = async_track_point_in_utc_time(
@@ -179,13 +183,13 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
         ir.async_create_issue(
             self.hass,
             DOMAIN,
-            self._cid,
+            self.config_entry.entry_id,
             is_fixable=False,
             severity=ir.IssueSeverity.WARNING,
             translation_key="expiring_soon",
             translation_placeholders={
-                "entry_id": self._cid,
-                "username": self._username,
+                "entry_id": self.config_entry.entry_id,
+                "username": cast(str, self.config_entry.unique_id),
             },
         )
 

--- a/custom_components/google_maps/coordinator.py
+++ b/custom_components/google_maps/coordinator.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 from asyncio import Lock
 from collections.abc import Callable
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 import logging
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_FINAL_WRITE
@@ -199,7 +200,16 @@ class GMConfigEntryParams:
     """Google Maps Config Entry Parameters."""
 
     coordinator: GMDataUpdateCoordinator
-    setup_with_acct_entity: bool
+    setup_data: dict[str, Any]
+    setup_options: dict[str, Any]
+
+    def __init__(
+        self, coordinator: GMDataUpdateCoordinator, entry: ConfigEntry
+    ) -> None:
+        """Initialize."""
+        self.coordinator = coordinator
+        self.setup_data = deepcopy(dict(entry.data))
+        self.setup_options = deepcopy(dict(entry.options))
 
 
 GMConfigEntry = ConfigEntry[GMConfigEntryParams]

--- a/custom_components/google_maps/coordinator.py
+++ b/custom_components/google_maps/coordinator.py
@@ -48,6 +48,7 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
     """Google Maps data update coordinator."""
 
     config_entry: ConfigEntry
+    _api: GMLocSharing
     _cookies_last_synced: datetime
     _unsub_exp: Callable[[], None] | None = None
 
@@ -57,7 +58,7 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
         self._create_acct_entity = entry.options[CONF_CREATE_ACCT_ENTITY]
 
         # The account's username is used as the config entry's unique ID.
-        self._api = GMLocSharing(cast(str, entry.unique_id))
+        self._account_email = cast(str, entry.unique_id)
         self.cookie_lock = Lock()
         self._unsub_final_write = hass.bus.async_listen_once(
             EVENT_HOMEASSISTANT_FINAL_WRITE, self._save_cookies_if_changed
@@ -98,6 +99,9 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
 
     async def _async_setup(self) -> None:
         """Set up the coordinator."""
+        self._api = await self.hass.async_add_executor_job(
+            GMLocSharing, self._account_email
+        )
         # Load the cookies before first update.
         async with self.cookie_lock:
             try:

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -138,19 +138,19 @@ async def async_setup_entry(
         #       the data is missing.
         assert uid not in missing
         missing[uid] = MissingParams(
-            name := entities[uid].log_name,
+            entities[uid].log_name,
             async_call_later(
                 hass, MISSING_DATA_GRACE_PERIOD, partial(remove_entity, uid)
             ),
         )
-        _LOGGER.warning("Data missing for %s", name)
 
     def unschedule_entity_removal(uid: UniqueID) -> None:
         """Unschedule removal of entity."""
-        params = missing.pop(uid)
-        if params.unsub:
-            params.unsub()
-        _LOGGER.warning("Data available again for %s", params.name)
+        mp = missing.pop(uid)
+        if mp.unsub:
+            mp.unsub()
+        else:
+            _LOGGER.warning("Data available again for %s", mp.name)
 
     async def remove_entity(uid: UniqueID, _: datetime) -> None:
         """Remove entity."""
@@ -160,10 +160,13 @@ async def async_setup_entry(
         #       back again, in which case, the entity will be recreated.
         # Need to do this with a lock so that update_entities can't create a new Entity
         # for the same UID that would add itself to the state machine, then the
-        # async_remove here would remove it from the state machine.
+        # async_remove here would remove it from the state machine. Also, two entities
+        # with the same UID could cause an error or a different entity ID (e.g., xx_2).
         async with lock:
-            assert missing[uid].unsub
-            missing[uid].unsub = None
+            mp = missing[uid]
+            _LOGGER.warning("Data missing for %s", mp.name)
+            assert mp.unsub
+            mp.unsub = None
             entity = entities.pop(uid)
             await entity.async_remove()
         # Do not release uid from unique_ids in case data comes back and entity can

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -1,16 +1,21 @@
 """Support for Google Maps location sharing."""
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from copy import copy
+from functools import partial
 import logging
 from typing import Any, cast
 
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.device_tracker.config_entry import (
+    DOMAIN as DT_DOMAIN,
+    TrackerEntity,
+)
 from homeassistant.const import ATTR_BATTERY_CHARGING
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_entity_registry_updated_event
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -40,12 +45,80 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: GMConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the device tracker platform."""
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
+
     cid = ConfigID(entry.entry_id)
     coordinator = entry.runtime_data.coordinator
+    max_gps_accuracy = entry.options[CONF_MAX_GPS_ACCURACY]
     unique_ids = hass.data[CFG_UNIQUE_IDS]
 
-    max_gps_accuracy = entry.options[CONF_MAX_GPS_ACCURACY]
     entities: dict[UniqueID, GoogleMapsDeviceTracker] = {}
+    registered_entities: dict[str, UniqueID] = {
+        ent.entity_id: UniqueID(ent.unique_id)
+        for ent in er.async_entries_for_config_entry(ent_reg, cid)
+        if ent.domain == DT_DOMAIN
+    }
+    unsub_ent_reg_updates: CALLBACK_TYPE | None = None
+
+    def stop_tracking_ent_reg_updates() -> None:
+        """Stop tracking entity registry updates."""
+        nonlocal unsub_ent_reg_updates
+
+        if unsub_ent_reg_updates:
+            unsub_ent_reg_updates()
+            unsub_ent_reg_updates = None
+
+    def track_ent_reg_updates() -> None:
+        """Track entity registry updates."""
+        nonlocal unsub_ent_reg_updates
+
+        stop_tracking_ent_reg_updates()
+        assert not unsub_ent_reg_updates
+        if registered_entities:
+            unsub_ent_reg_updates = async_track_entity_registry_updated_event(
+                hass,
+                # Provide a copy of the current keys so tracking/removing is not
+                # affected by updates to the dict.
+                list(registered_entities),
+                entity_registry_updated,
+            )
+
+    # Needs to be a callback so it doesn't get run in an executor by
+    # async_track_entity_registry_updated_event.
+    @callback
+    def entity_registry_updated(
+        event: Event[er.EventEntityRegistryUpdatedData],
+    ) -> None:
+        """Handle entity removed from entity registry."""
+        if (action := event.data["action"]) not in ("remove", "update"):
+            return
+
+        entity_id = event.data["entity_id"]
+        if action == "remove":
+            uid = registered_entities.pop(entity_id)
+            track_ent_reg_updates()
+
+            device = dev_reg.async_get_device(dev_ids(uid))
+            if not device:
+                # TODO: Remove warning???
+                _LOGGER.warning(
+                    "Could not find device for removed entity: %s", entity_id
+                )
+                return
+            dev_reg.async_remove_device(device.id)
+
+        # update
+        elif old_entity_id := cast(str | None, event.data.get("old_entity_id")):
+            track_entity(registered_entities.pop(old_entity_id), entity_id)
+
+    def track_entity(uid: UniqueID, entity_id: str) -> None:
+        """Track entity registry updates for entity."""
+        if entity_id in registered_entities:
+            assert registered_entities[entity_id] == uid
+            return
+        registered_entities[entity_id] = uid
+        track_ent_reg_updates()
 
     @callback
     def update_entities() -> None:
@@ -67,14 +140,18 @@ async def async_setup_entry(
                 # added next time entry loads.
         if create_uids := unique_ids.take(cid, uids) - entities.keys():
             new_entities = {
-                uid: GoogleMapsDeviceTracker(coordinator, uid, max_gps_accuracy)
+                uid: GoogleMapsDeviceTracker(
+                    coordinator, uid, max_gps_accuracy, partial(track_entity, uid)
+                )
                 for uid in create_uids
             }
             async_add_entities(new_entities.values())
             entities.update(new_entities)
 
+    track_ent_reg_updates()
     update_entities()
     entry.async_on_unload(coordinator.async_add_listener(update_entities))
+    entry.async_on_unload(stop_tracking_ent_reg_updates)
 
 
 class GoogleMapsDeviceTracker(
@@ -93,7 +170,11 @@ class GoogleMapsDeviceTracker(
     _skip_reason: str = ""
 
     def __init__(
-        self, coordinator: GMDataUpdateCoordinator, uid: UniqueID, max_gps_accuracy: int
+        self,
+        coordinator: GMDataUpdateCoordinator,
+        uid: UniqueID,
+        max_gps_accuracy: int,
+        track_entity: Callable[[str], None],
     ) -> None:
         """Initialize Google Maps Device Tracker."""
         super().__init__(coordinator)
@@ -114,6 +195,7 @@ class GoogleMapsDeviceTracker(
         self._attr_device_info = dr.DeviceInfo(  # type: ignore[assignment]
             identifiers=dev_ids(uid), name=name, serial_number=uid
         )
+        self._track_entity = track_entity
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any]:
@@ -176,6 +258,8 @@ class GoogleMapsDeviceTracker(
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
+
+        self._track_entity(self.entity_id)
 
         # Restore state if possible.
         if (last_extra_data := await self.async_get_last_extra_data()) and (

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -123,12 +123,15 @@ async def async_setup_entry(
     @callback
     def update_entities() -> None:
         """Update entities for people."""
+        # TODO: Do not remove entity unless its data is missing for a number of updates.
+        #       It seems it's possible for data to disappear for a bit but then come
+        #       back.
         uids = frozenset(coordinator.data)
         # NOTE: Unique ID of "account entity" is the account's email address.
         if remove_uids := entities.keys() - uids:
             for remove_uid in remove_uids:
                 entity = entities.pop(remove_uid)
-                _LOGGER.warning("Data no longer available for %s", entity.name)
+                _LOGGER.warning("Data no longer available for %s", entity.log_name)
                 entry.async_create_background_task(
                     hass, entity.async_remove(), "Remove GoogleMapsDeviceTracker entity"
                 )
@@ -255,6 +258,16 @@ class GoogleMapsDeviceTracker(
         # TODO: Still save/restore misc???
         return PersonData(self._loc, self._misc)
 
+    @property
+    def log_name(self) -> str:
+        """Return name to be used in log messages."""
+        return (
+            (self.registry_entry and self.registry_entry.name)
+            or self._friendly_name_internal()
+            or self.entity_id
+            or self._misc.full_name
+        )
+
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
@@ -332,4 +345,4 @@ class GoogleMapsDeviceTracker(
         """Log reason for ignoring location data."""
         if reason != self._skip_reason:
             self._skip_reason = reason
-            _LOGGER.debug("Ignoring %s location data because %s", self.name, reason)
+            _LOGGER.debug("Ignoring %s location data because %s", self.log_name, reason)

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -323,7 +323,10 @@ class GoogleMapsDeviceTracker(
         """Return name to be used in log messages."""
         return (
             (self.registry_entry and self.registry_entry.name)
-            or self._friendly_name_internal()
+            or (
+                (device_entry := self.device_entry)
+                and (device_entry.name_by_user or device_entry.name)
+            )
             or self.entity_id
             or self._misc.full_name
         )

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -52,6 +52,7 @@ async def async_setup_entry(
     def update_entities() -> None:
         """Update entities for people."""
         uids = frozenset(coordinator.data)
+        # NOTE: Unique ID of "account entity" is the account's email address.
         if remove_uids := entities.keys() - uids:
             for remove_uid in remove_uids:
                 entity = entities.pop(remove_uid)
@@ -95,6 +96,7 @@ class GoogleMapsDeviceTracker(
     ) -> None:
         """Initialize Google Maps Device Tracker."""
         super().__init__(coordinator)
+        # NOTE: Unique ID of "account entity" is the account's email address.
         self._attr_unique_id = uid
         self._max_gps_accuracy = max_gps_accuracy
 

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -36,14 +36,7 @@ from .const import (
     MISSING_DATA_GRACE_PERIOD,
 )
 from .coordinator import GMConfigEntry, GMDataUpdateCoordinator
-from .helpers import (
-    CFG_UNIQUE_IDS,
-    ConfigID,
-    LocationData,
-    PersonData,
-    UniqueID,
-    dev_ids,
-)
+from .helpers import CFG_UNIQUE_IDS, ConfigID, LocationData, UniqueID, dev_ids
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -318,10 +311,9 @@ class GoogleMapsDeviceTracker(
         return self._loc.longitude
 
     @property
-    def extra_restore_state_data(self) -> PersonData:
+    def extra_restore_state_data(self) -> LocationData | None:
         """Return Google Maps specific state data to be restored."""
-        # TODO: Still save/restore misc???
-        return PersonData(self._loc, self._misc)
+        return self._loc
 
     @property
     def log_name(self) -> str:
@@ -337,15 +329,22 @@ class GoogleMapsDeviceTracker(
         """Run when entity about to be added to hass."""
         await super().async_added_to_hass()
 
+        # Now that entity ID has been determined, add it to list of entity IDs to
+        # monitor being removed from entity registry.
         self._track_entity(self.entity_id)
 
         # Restore state if possible.
-        if (last_extra_data := await self.async_get_last_extra_data()) and (
-            last_person_data := PersonData.from_dict(last_extra_data.as_dict())
-        ):
-            # Always restore loc data as "previous location" first, then overwrite
-            # with new location below if available and "better."
-            self._loc = last_person_data.loc
+        if last_extra_data := await self.async_get_last_extra_data():
+            # Previous versions stored PersonData which included misc & loc.
+            # Now only loc is stored directly.
+            last_extra_data_dict: dict[str, Any] = last_extra_data.as_dict()
+            if last_loc_data_dict := cast(
+                dict[str, Any] | None,
+                last_extra_data_dict.get("loc", last_extra_data_dict),
+            ):
+                # Always restore loc data as "previous location" first, then overwrite
+                # with new location below if available and "better."
+                self._loc = LocationData.from_dict(last_loc_data_dict)
 
         # Now that previous state has been restored, update with new data if possible.
         # Note that although the Entity was created only when data for this uid was

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -12,9 +12,8 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util, slugify
+from homeassistant.util import dt as dt_util
 
 from .const import (
     ATTR_ADDRESS,
@@ -85,6 +84,8 @@ class GoogleMapsDeviceTracker(
 
     _unrecorded_attributes = DT_NO_RECORD_ATTRS
     _attr_attribution = ATTRIBUTION
+    # With name == None and has_entity_name == True, entity will get device's name.
+    _attr_name = None
     _attr_has_entity_name = True
     _attr_translation_key = "tracker"
 
@@ -105,19 +106,14 @@ class GoogleMapsDeviceTracker(
         assert data.misc
         self._misc = copy(data.misc)
         full_name = data.misc.full_name
-        self._attr_translation_placeholders = {"full_name": full_name}
+        name = f"Google Maps {full_name}"
         # For some reason, the device_tracker component doesn't allow entity to be
         # associated with a device. This appears to be for some legacy reason that no
         # longer exists or makes sense. E.g., some built-in integrations assign device
         # info for device_tracker entities.
         self._attr_device_info = dr.DeviceInfo(  # type: ignore[assignment]
-            identifiers=dev_ids(uid), name=full_name, serial_number=uid
+            identifiers=dev_ids(uid), name=name, serial_number=uid
         )
-
-    @property
-    def suggested_object_id(self) -> str:
-        """Return input for object ID."""
-        return slugify(cast(str, self.name))
 
     @property
     def extra_state_attributes(self) -> Mapping[str, Any]:
@@ -176,17 +172,6 @@ class GoogleMapsDeviceTracker(
         """Return Google Maps specific state data to be restored."""
         # TODO: Still save/restore misc???
         return PersonData(self._loc, self._misc)
-
-    def _friendly_name_internal(self) -> str | None:
-        """Return the friendly name.
-
-        It does not make sense to use device name in front of entity name since device
-        name is effectively part of entity name since they both come from full name.
-        """
-        name = self.name
-        if name is UNDEFINED:
-            return None
-        return name
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -6,14 +6,13 @@ from copy import copy
 import logging
 from typing import Any, cast
 
-from homeassistant.components.device_tracker import DOMAIN as DT_DOMAIN, SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.const import ATTR_BATTERY_CHARGING
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util, slugify
 
@@ -23,18 +22,16 @@ from .const import (
     ATTR_NICKNAME,
     ATTRIBUTION,
     CONF_MAX_GPS_ACCURACY,
-    DOMAIN,
     DT_NO_RECORD_ATTRS,
-    NAME_PREFIX,
 )
 from .coordinator import GMConfigEntry, GMDataUpdateCoordinator
 from .helpers import (
     CFG_UNIQUE_IDS,
     ConfigID,
     LocationData,
-    MiscData,
     PersonData,
     UniqueID,
+    dev_ids,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,29 +41,40 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: GMConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the device tracker platform."""
-    cid = cast(ConfigID, entry.entry_id)
-    coordinator = entry.runtime_data
+    cid = ConfigID(entry.entry_id)
+    coordinator = entry.runtime_data.coordinator
     unique_ids = hass.data[CFG_UNIQUE_IDS]
 
     max_gps_accuracy = entry.options[CONF_MAX_GPS_ACCURACY]
-    created_uids: set[UniqueID] = set()
+    entities: dict[UniqueID, GoogleMapsDeviceTracker] = {}
 
     @callback
-    def create_entities(reg_uids: frozenset[UniqueID] = frozenset()) -> None:
-        """Create entities for newly seen people and optionally registered ones."""
-        if create_uids := (
-            unique_ids.take(cid, set(coordinator.data) | reg_uids) - created_uids
-        ):
-            async_add_entities(
-                [
-                    GoogleMapsDeviceTracker(coordinator, uid, max_gps_accuracy)
-                    for uid in create_uids
-                ]
-            )
-            created_uids.update(create_uids)
+    def update_entities() -> None:
+        """Update entities for people."""
+        uids = frozenset(coordinator.data)
+        if remove_uids := entities.keys() - uids:
+            for remove_uid in remove_uids:
+                entity = entities.pop(remove_uid)
+                _LOGGER.warning("Data no longer available for %s", entity.name)
+                entry.async_create_background_task(
+                    hass, entity.async_remove(), "Remove GoogleMapsDeviceTracker entity"
+                )
+                # Do not release uid from unique_ids in case data comes back and entity
+                # can be created again. It will still be in the Entity Registry, at least
+                # if and until the user removes it from the registry. And even then, no
+                # need to release the uid from unique_ids since it's not likely to come
+                # back and it will be released if entry gets unloaded and it won't get
+                # added next time entry loads.
+        if create_uids := unique_ids.take(cid, uids) - entities.keys():
+            new_entities = {
+                uid: GoogleMapsDeviceTracker(coordinator, uid, max_gps_accuracy)
+                for uid in create_uids
+            }
+            async_add_entities(new_entities.values())
+            entities.update(new_entities)
 
-    create_entities(unique_ids.owned(cid))
-    entry.async_on_unload(coordinator.async_add_listener(create_entities))
+    update_entities()
+    entry.async_on_unload(coordinator.async_add_listener(update_entities))
 
 
 class GoogleMapsDeviceTracker(
@@ -76,9 +84,9 @@ class GoogleMapsDeviceTracker(
 
     _unrecorded_attributes = DT_NO_RECORD_ATTRS
     _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
     _attr_translation_key = "tracker"
 
-    _misc: MiscData | None = None
     _loc: LocationData | None = None
     _skip_reason: str = ""
 
@@ -90,28 +98,18 @@ class GoogleMapsDeviceTracker(
         self._attr_unique_id = uid
         self._max_gps_accuracy = max_gps_accuracy
 
-        # Use misc data now if available. Loc data will be handled in
-        # async_added_to_hass.
-        if data := coordinator.data.get(uid):
-            assert data.misc
-            self._full_name = data.misc.full_name
-            self._attr_name = f"{NAME_PREFIX} {self._full_name}"
-            self._misc = copy(data.misc)
-        else:
-            # Created from Entity Registry. Get name from there.
-            # The rest is restored in async_added_to_hass if possible.
-            ent_reg = er.async_get(coordinator.hass)
-            self._attr_name = ent_reg.entities[
-                cast(
-                    str,
-                    ent_reg.async_get_entity_id(DT_DOMAIN, DOMAIN, uid),
-                )
-            ].original_name
-            self._full_name = cast(str, self._attr_name).removeprefix(f"{NAME_PREFIX} ")
-        self._attr_device_info = DeviceInfo(  # type: ignore[assignment]
-            identifiers={(DOMAIN, uid)},
-            name=self._full_name,
-            serial_number=uid,
+        # Use misc data now. Loc data will be handled in async_added_to_hass.
+        data = coordinator.data[uid]
+        assert data.misc
+        self._misc = copy(data.misc)
+        full_name = data.misc.full_name
+        self._attr_translation_placeholders = {"full_name": full_name}
+        # For some reason, the device_tracker component doesn't allow entity to be
+        # associated with a device. This appears to be for some legacy reason that no
+        # longer exists or makes sense. E.g., some built-in integrations assign device
+        # info for device_tracker entities.
+        self._attr_device_info = dr.DeviceInfo(  # type: ignore[assignment]
+            identifiers=dev_ids(uid), name=full_name, serial_number=uid
         )
 
     @property
@@ -120,10 +118,8 @@ class GoogleMapsDeviceTracker(
         return slugify(cast(str, self.name))
 
     @property
-    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+    def extra_state_attributes(self) -> Mapping[str, Any]:
         """Return entity specific state attributes."""
-        if self._misc is None:
-            return None
         attrs: dict[str, Any] = {ATTR_NICKNAME: self._misc.nickname}
         if (charging := self._misc.battery_charging) is not None:
             attrs[ATTR_BATTERY_CHARGING] = charging
@@ -135,8 +131,6 @@ class GoogleMapsDeviceTracker(
     @property
     def entity_picture(self) -> str | None:
         """Return the entity picture to use in the frontend, if any."""
-        if self._misc is None:
-            return None
         return self._misc.entity_picture
 
     @property
@@ -152,14 +146,7 @@ class GoogleMapsDeviceTracker(
     @property
     def battery_level(self) -> int | None:
         """Return the battery level of the device."""
-        if self._misc is None:
-            return None
         return self._misc.battery_level
-
-    @property
-    def source_type(self) -> SourceType:
-        """Return the source type of the device."""
-        return SourceType.GPS
 
     @property
     def location_accuracy(self) -> int:
@@ -185,7 +172,19 @@ class GoogleMapsDeviceTracker(
     @property
     def extra_restore_state_data(self) -> PersonData:
         """Return Google Maps specific state data to be restored."""
+        # TODO: Still save/restore misc???
         return PersonData(self._loc, self._misc)
+
+    def _friendly_name_internal(self) -> str | None:
+        """Return the friendly name.
+
+        It does not make sense to use device name in front of entity name since device
+        name is effectively part of entity name since they both come from full name.
+        """
+        name = self.name
+        if name is UNDEFINED:
+            return None
+        return name
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -198,11 +197,11 @@ class GoogleMapsDeviceTracker(
             # Always restore loc data as "previous location" first, then overwrite
             # with new location below if available and "better."
             self._loc = last_person_data.loc
-            # Only restore misc data if we didn't get any when initialized.
-            if self._misc is None:
-                self._misc = last_person_data.misc
 
         # Now that previous state has been restored, update with new data if possible.
+        # Note that although the Entity was created only when data for this uid was
+        # available, it's possible (although not very likely) for the coordinator to
+        # have updated since then and now there is no data for this uid.
         if not (data := self.coordinator.data.get(cast(UniqueID, self.unique_id))):
             return
         assert data.loc
@@ -212,9 +211,7 @@ class GoogleMapsDeviceTracker(
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if not (data := self.coordinator.data.get(cast(UniqueID, self.unique_id))):
-            # TODO: Should we do anything special if data is not available, at least
-            # after first update, e.g., become unavailable, unknown or retored???
-            # And, if restored, do that by deleting ourselves???
+            # Data no longer availble. Entity will be removed.
             return
         assert data.misc
         assert data.loc

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -1,8 +1,11 @@
 """Support for Google Maps location sharing."""
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable, Mapping
 from copy import copy
+from dataclasses import dataclass
+from datetime import datetime
 from functools import partial
 import logging
 from typing import Any, cast
@@ -15,7 +18,10 @@ from homeassistant.const import ATTR_BATTERY_CHARGING
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.event import async_track_entity_registry_updated_event
+from homeassistant.helpers.event import (
+    async_call_later,
+    async_track_entity_registry_updated_event,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
@@ -27,6 +33,7 @@ from .const import (
     ATTRIBUTION,
     CONF_MAX_GPS_ACCURACY,
     DT_NO_RECORD_ATTRS,
+    MISSING_DATA_GRACE_PERIOD,
 )
 from .coordinator import GMConfigEntry, GMDataUpdateCoordinator
 from .helpers import (
@@ -41,6 +48,14 @@ from .helpers import (
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass
+class MissingParams:
+    """Missing parameters."""
+
+    name: str
+    unsub: CALLBACK_TYPE | None
+
+
 async def async_setup_entry(
     hass: HomeAssistant, entry: GMConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
@@ -53,7 +68,9 @@ async def async_setup_entry(
     max_gps_accuracy = entry.options[CONF_MAX_GPS_ACCURACY]
     unique_ids = hass.data[CFG_UNIQUE_IDS]
 
+    lock = asyncio.Lock()
     entities: dict[UniqueID, GoogleMapsDeviceTracker] = {}
+    missing: dict[UniqueID, MissingParams] = {}
     registered_entities: dict[str, UniqueID] = {
         ent.entity_id: UniqueID(ent.unique_id)
         for ent in er.async_entries_for_config_entry(ent_reg, cid)
@@ -120,40 +137,88 @@ async def async_setup_entry(
         registered_entities[entity_id] = uid
         track_ent_reg_updates()
 
-    @callback
-    def update_entities() -> None:
+    def schedule_entity_removal(uid: UniqueID) -> None:
+        """Schedule an entity to be removed."""
+        # NOTE: The entity is not removed immediately because there are times when a
+        #       person's data goes missing for a little while, but then comes back again
+        #       on its own. The state of the entity will just not update during the time
+        #       the data is missing.
+        assert uid not in missing
+        missing[uid] = MissingParams(
+            name := entities[uid].log_name,
+            async_call_later(
+                hass, MISSING_DATA_GRACE_PERIOD, partial(remove_entity, uid)
+            ),
+        )
+        _LOGGER.warning("Data missing for %s", name)
+
+    def unschedule_entity_removal(uid: UniqueID) -> None:
+        """Unschedule removal of entity."""
+        params = missing.pop(uid)
+        if params.unsub:
+            params.unsub()
+        _LOGGER.warning("Data available again for %s", params.name)
+
+    async def remove_entity(uid: UniqueID, _: datetime) -> None:
+        """Remove entity."""
+        # NOTE: They will still be in the entity registry, so they will still exist in
+        #       HA's state machine, but they will become unavailable. The user can then
+        #       completely remove them if they want. Unless, of course, their data comes
+        #       back again, in which case, the entity will be recreated.
+        # Need to do this with a lock so that update_entities can't create a new Entity
+        # for the same UID that would add itself to the state machine, then the
+        # async_remove here would remove it from the state machine.
+        async with lock:
+            assert missing[uid].unsub
+            missing[uid].unsub = None
+            entity = entities.pop(uid)
+            await entity.async_remove()
+        # Do not release uid from unique_ids in case data comes back and entity can
+        # be created again. It will still be in the Entity Registry, at least if and
+        # until the user removes it from the registry. And even then, no need to
+        # release the uid from unique_ids since it's not likely to come back and it
+        # will be released if entry gets unloaded and it won't get added next time
+        # entry loads.
+
+    async def update_entities() -> None:
         """Update entities for people."""
-        # TODO: Do not remove entity unless its data is missing for a number of updates.
-        #       It seems it's possible for data to disappear for a bit but then come
-        #       back.
-        uids = frozenset(coordinator.data)
-        # NOTE: Unique ID of "account entity" is the account's email address.
-        if remove_uids := entities.keys() - uids:
-            for remove_uid in remove_uids:
-                entity = entities.pop(remove_uid)
-                _LOGGER.warning("Data no longer available for %s", entity.log_name)
-                entry.async_create_background_task(
-                    hass, entity.async_remove(), "Remove GoogleMapsDeviceTracker entity"
-                )
-                # Do not release uid from unique_ids in case data comes back and entity
-                # can be created again. It will still be in the Entity Registry, at least
-                # if and until the user removes it from the registry. And even then, no
-                # need to release the uid from unique_ids since it's not likely to come
-                # back and it will be released if entry gets unloaded and it won't get
-                # added next time entry loads.
-        if create_uids := unique_ids.take(cid, uids) - entities.keys():
-            new_entities = {
-                uid: GoogleMapsDeviceTracker(
-                    coordinator, uid, max_gps_accuracy, partial(track_entity, uid)
-                )
-                for uid in create_uids
-            }
-            async_add_entities(new_entities.values())
-            entities.update(new_entities)
+        async with lock:
+            # NOTE: Unique ID of "account entity" is the account's email address.
+            uids = frozenset(coordinator.data)
+
+            # For any entity that was scheduled to be removed due to its data being
+            # missing, cancel the removal if the data is available again.
+            for uid in missing.keys() & uids:
+                unschedule_entity_removal(uid)
+
+            # For any newly missing data, schedule a task to remove the entity after a
+            # grace period.
+            for uid in entities.keys() - uids - missing.keys():
+                schedule_entity_removal(uid)
+
+            # Attempt to take ownership of any unique IDs that have not yet been taken
+            # by other config entries, and create entities for those that have been
+            # "taken" and have not had entities created yet.
+            if create_uids := unique_ids.take(cid, uids) - entities.keys():
+                new_entities = {
+                    uid: GoogleMapsDeviceTracker(
+                        coordinator, uid, max_gps_accuracy, partial(track_entity, uid)
+                    )
+                    for uid in create_uids
+                }
+                async_add_entities(new_entities.values())
+                entities.update(new_entities)
+
+    @callback
+    def update_entities_cb() -> None:
+        """Update entities for people."""
+        entry.async_create_background_task(
+            hass, update_entities(), f"Update entities for {entry.title}"
+        )
 
     track_ent_reg_updates()
-    update_entities()
-    entry.async_on_unload(coordinator.async_add_listener(update_entities))
+    await update_entities()
+    entry.async_on_unload(coordinator.async_add_listener(update_entities_cb))
     entry.async_on_unload(stop_tracking_ent_reg_updates)
 
 
@@ -295,7 +360,8 @@ class GoogleMapsDeviceTracker(
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if not (data := self.coordinator.data.get(cast(UniqueID, self.unique_id))):
-            # Data no longer availble. Entity will be removed.
+            # Data not availble. Keep current data for now.
+            # If data is not available long enough, Entity will be removed.
             return
         assert data.misc
         assert data.loc

--- a/custom_components/google_maps/gm_loc_sharing.py
+++ b/custom_components/google_maps/gm_loc_sharing.py
@@ -131,7 +131,10 @@ class GMPerson:
 
     @classmethod
     def acct_from_data(cls, data: Sequence[Any], account_email: str) -> Self | None:
-        """Initialize account holder from server data."""
+        """Initialize account holder from server data.
+
+        id wll be account's email address.
+        """
         try:
             return cls(
                 account_email,
@@ -249,7 +252,10 @@ class GMLocSharing:
             raise InvalidData(f"Unexpected parsed data: {self._data}") from None
 
     def get_people(self, include_acct_person: bool) -> list[GMPerson]:
-        """Get people from data."""
+        """Get people from data.
+
+        If including "account person", its id will be the account's email address.
+        """
         people: list[GMPerson] = []
         bad_data: list[list[Any]] = []
         if len(self._data) < 1:

--- a/custom_components/google_maps/helpers.py
+++ b/custom_components/google_maps/helpers.py
@@ -179,10 +179,9 @@ class ConfigUniqueIDs:
     Since multiple Google accounts might be added, and it's possible for people to have
     shared their location with more than one of those accounts, to avoid having the same
     Entity being created by more than one account (i.e., ConfigEntry), keep a record of
-    which config each entity is, or will be, associated with. This will not only avoid
-    having to keep querying the Entity Registry, it will also avoid race conditions
-    where multiple configs might try to create an Entity for the same shared person at
-    the same time.
+    which config each entity is associated with. This will not only avoid having to keep
+    querying the Entity Registry, it will also avoid race conditions where multiple
+    configs might try to create an Entity for the same shared person at the same time.
 
     Do not consider disabled config entries. Any entity registered with a disabled
     config entry will be "up for grabs" and can be "taken" by another, enabled config

--- a/custom_components/google_maps/helpers.py
+++ b/custom_components/google_maps/helpers.py
@@ -18,6 +18,8 @@ from .const import COOKIE_WARNING_PERIOD, CREDENTIALS_FILE, DOMAIN
 from .gm_loc_sharing import GMPerson
 
 CFG_UNIQUE_IDS: HassKey[ConfigUniqueIDs] = HassKey(DOMAIN)
+ConfigID = NewType("ConfigID", str)
+UniqueID = NewType("UniqueID", str)
 
 
 def old_cookies_file_path(hass: HomeAssistant, username: str) -> Path:
@@ -42,8 +44,9 @@ def expiring_soon(expiration: datetime | None) -> bool:
     )
 
 
-ConfigID = NewType("ConfigID", str)
-UniqueID = NewType("UniqueID", str)
+def dev_ids(uid: UniqueID) -> set[tuple[str, str]]:
+    """Return device identifiers for unique ID."""
+    return {(DOMAIN, uid)}
 
 
 class FromAttributesError(Exception):
@@ -173,13 +176,19 @@ class PersonData(ExtraStoredData):
 class ConfigUniqueIDs:
     """Unique ID config assignments.
 
-    Since multiple Google accounts might be be added, and it's possible for people to
-    have shared their location with more than one of those accounts, to avoid having the
-    same Entity being created by more than one account (i.e., ConfigEntry), keep a
-    record of which config each entity is, or will be, associated with. This will not
-    only avoid having to keep querying the Entity Registry, it will also avoid race
-    conditions where multiple configs might try to create an Entity for the same shared
-    person at the same time.
+    Since multiple Google accounts might be added, and it's possible for people to have
+    shared their location with more than one of those accounts, to avoid having the same
+    Entity being created by more than one account (i.e., ConfigEntry), keep a record of
+    which config each entity is, or will be, associated with. This will not only avoid
+    having to keep querying the Entity Registry, it will also avoid race conditions
+    where multiple configs might try to create an Entity for the same shared person at
+    the same time.
+
+    Do not consider disabled config entries. Any entity registered with a disabled
+    config entry will be "up for grabs" and can be "taken" by another, enabled config
+    entry. Also, if/when a config entry gets disabled, any entities it did own must be
+    released as well. If/when it gets re-enabled, it can attempt to take any entities it
+    used to own if another config entry hasn't taken them in the meantime.
     """
 
     def __init__(self, hass: HomeAssistant) -> None:
@@ -188,54 +197,42 @@ class ConfigUniqueIDs:
         self._cfg_uids: dict[ConfigID, set[UniqueID]] = {}
 
         ent_reg = er.async_get(hass)
-        for cfg in hass.config_entries.async_entries(DOMAIN):
-            cid = cast(ConfigID, cfg.entry_id)
+        for cfg in hass.config_entries.async_entries(DOMAIN, include_disabled=False):
+            cid = ConfigID(cfg.entry_id)
             cfg_uids = {
-                cast(UniqueID, ent.unique_id)
+                UniqueID(ent.unique_id)
                 for ent in er.async_entries_for_config_entry(ent_reg, cid)
                 if ent.domain == DT_DOMAIN
             }
+            if not cfg_uids:
+                continue
             self._all_uids.update(cfg_uids)
             self._cfg_uids[cid] = cfg_uids
-
-    @property
-    def empty(self) -> bool:
-        """Return if no unique IDs are assigned to any config."""
-        if not self._all_uids:
-            assert not self._cfg_uids
-            return True
-        return False
-
-    def own(self, cid: ConfigID, uid: UniqueID) -> bool:
-        """Return if config already owns unique ID."""
-        return uid in self.owned(cid)
 
     def owned(self, cid: ConfigID) -> frozenset[UniqueID]:
         """Return unique IDs owned by config."""
         return frozenset(self._cfg_uids.get(cid, set()))
 
-    def owned_by_others(self, cid: ConfigID) -> set[UniqueID]:
-        """Return unique IDs that are owned by other configs."""
-        return self._all_uids - self.owned(cid)
-
-    def take(self, cid: ConfigID, uids: set[UniqueID]) -> set[UniqueID]:
+    def take(self, cid: ConfigID, uids: frozenset[UniqueID]) -> frozenset[UniqueID]:
         """Take ownership of a set of unique IDs.
 
         Returns set of unique IDs actually taken;
         i.e., that did not already belong to other configs.
         """
-        uids = uids - self.owned_by_others(cid)
+        uids -= self._all_uids - self.owned(cid)
         self._all_uids.update(uids)
         self._cfg_uids.setdefault(cid, set()).update(uids)
         return uids
 
     def release(self, cid: ConfigID, uid: UniqueID) -> None:
-        """Release ownership of a single unique ID if not owned by another config."""
-        if uid in self.owned_by_others(cid):
+        """Release ownership of a single unique ID if owned by config."""
+        if uid not in self.owned(cid):
             return
-        self._all_uids.discard(uid)
-        self._cfg_uids[cid].discard(uid)
+        self._all_uids.remove(uid)
+        self._cfg_uids[cid].remove(uid)
+        if not self._cfg_uids[cid]:
+            del self._cfg_uids[cid]
 
-    def remove(self, cid: ConfigID) -> None:
-        """Remove config, releasing any unique IDs it owned."""
-        self._all_uids.difference_update(self._cfg_uids.pop(cid, set()))
+    def release_all(self, cid: ConfigID) -> None:
+        """Release all unique IDs owned by config."""
+        self._all_uids -= self._cfg_uids.pop(cid, set())

--- a/custom_components/google_maps/helpers.py
+++ b/custom_components/google_maps/helpers.py
@@ -1,6 +1,7 @@
 """Google Maps helper functions, etc."""
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import asdict as dc_asdict, dataclass
 from datetime import datetime
 from pathlib import Path
@@ -193,7 +194,7 @@ class ConfigUniqueIDs:
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize assignments from Entity Registry."""
         self._all_uids: set[UniqueID] = set()
-        self._cfg_uids: dict[ConfigID, set[UniqueID]] = {}
+        self._cfg_uids: defaultdict[ConfigID, set[UniqueID]] = defaultdict(set)
 
         ent_reg = er.async_get(hass)
         for cfg in hass.config_entries.async_entries(DOMAIN, include_disabled=False):
@@ -220,7 +221,7 @@ class ConfigUniqueIDs:
         """
         uids -= self._all_uids - self.owned(cid)
         self._all_uids.update(uids)
-        self._cfg_uids.setdefault(cid, set()).update(uids)
+        self._cfg_uids[cid].update(uids)
         return uids
 
     def release(self, cid: ConfigID, uid: UniqueID) -> None:

--- a/custom_components/google_maps/helpers.py
+++ b/custom_components/google_maps/helpers.py
@@ -55,7 +55,7 @@ class FromAttributesError(Exception):
 
 
 @dataclass(frozen=True)
-class LocationData:
+class LocationData(ExtraStoredData):
     """Location data."""
 
     address: str
@@ -115,24 +115,6 @@ class MiscData:
     full_name: str
     nickname: str
 
-    def as_dict(self) -> dict[str, Any]:
-        """Return a dict representation of the data."""
-        return dc_asdict(self)
-
-    @classmethod
-    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
-        """Initialize miscellaneous data from a dict."""
-        try:
-            return cls(
-                restored["battery_charging"],
-                restored["battery_level"],
-                restored["entity_picture"],
-                restored["full_name"],
-                restored["nickname"],
-            )
-        except KeyError:
-            return None
-
     @classmethod
     def from_person(cls, person: GMPerson) -> Self:
         """Initialize miscellaneous data from GMPerson object."""
@@ -146,24 +128,11 @@ class MiscData:
 
 
 @dataclass(frozen=True)
-class PersonData(ExtraStoredData):
+class PersonData:
     """Shared person data."""
 
-    loc: LocationData | None
-    misc: MiscData | None
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return a dict representation of the data."""
-        return dc_asdict(self)
-
-    @classmethod
-    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
-        """Return PersonData created from a dict."""
-        if (loc := restored.get("loc")) is not None:
-            loc = LocationData.from_dict(loc)
-        if (misc := restored.get("misc")) is not None:
-            misc = MiscData.from_dict(misc)
-        return cls(loc, misc)
+    loc: LocationData
+    misc: MiscData
 
     @classmethod
     def from_person(cls, person: GMPerson) -> Self:

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/1.5.0/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/2.0.0b0/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
   "requirements": [],
-  "version": "1.5.0"
+  "version": "2.0.0b0"
 }

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/2.0.0b3/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/2.0.0b4/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
   "requirements": [],
-  "version": "2.0.0b3"
+  "version": "2.0.0b4"
 }

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/2.0.0b0/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/2.0.0b2/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
   "requirements": [],
-  "version": "2.0.0b0"
+  "version": "2.0.0b2"
 }

--- a/custom_components/google_maps/manifest.json
+++ b/custom_components/google_maps/manifest.json
@@ -4,10 +4,10 @@
   "codeowners": ["@pnbruckner"],
   "config_flow": true,
   "dependencies": ["file_upload"],
-  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/2.0.0b2/README.md",
+  "documentation": "https://github.com/pnbruckner/ha-google-maps/blob/2.0.0b3/README.md",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/pnbruckner/ha-google-maps/issues",
   "loggers": [],
   "requirements": [],
-  "version": "2.0.0b2"
+  "version": "2.0.0b3"
 }

--- a/custom_components/google_maps/translations/en.json
+++ b/custom_components/google_maps/translations/en.json
@@ -4,7 +4,7 @@
             "reauth_successful": "Re-authentication was successful"
         },
         "error": {
-            "already_configured_account": "Account is already configured",
+            "already_configured": "Account is already configured",
             "invalid_cookies_file": "Invalid cookies file."
         },
         "step": {
@@ -77,7 +77,7 @@
                 },
                 "title": "Uploaded Cookies"
             },
-            "user": {
+            "username": {
                 "data": {
                     "username": "Username"
                 },
@@ -114,7 +114,7 @@
     },
     "issues": {
         "duplicate_usernames": {
-            "description": "{usernames} used in multiple integration entries which is no longer allowed.\n\nAny integration entry that shared a username with other entries will have failed to load. To fix, [click here](/config/integrations/integration/google_maps), remove all but one integration entry for each username, then reload failed entries.",
+            "description": "{usernames} used in multiple integration entries which is no longer allowed.\n\nTo fix, [click here](/config/integrations/integration/google_maps), remove all but one integration entry for each username, then restart Home Assistant.",
             "title": "Duplicate Usernames"
         },
         "expiring_soon": {

--- a/custom_components/google_maps/translations/en.json
+++ b/custom_components/google_maps/translations/en.json
@@ -4,6 +4,7 @@
             "reauth_successful": "Re-authentication was successful"
         },
         "error": {
+            "already_configured_account": "Account is already configured",
             "invalid_cookies_file": "Invalid cookies file."
         },
         "step": {
@@ -86,8 +87,14 @@
         }
     },
     "entity": {
+        "binary_sensor": {
+            "online": {
+                "name": "Google Maps {title} online"
+            }
+        },
         "device_tracker": {
             "tracker": {
+                "name": "Google Maps {full_name}",
                 "state_attributes": {
                     "address": {
                         "name": "Address"
@@ -106,6 +113,10 @@
         }
     },
     "issues": {
+        "duplicate_usernames": {
+            "description": "{usernames} used in multiple integration entries which is no longer allowed.\n\nAny integration entry that shared a username with other entries will have failed to load. To fix, [click here](/config/integrations/integration/google_maps), remove all but one integration entry for each username, then reload failed entries.",
+            "title": "Duplicate Usernames"
+        },
         "expiring_soon": {
             "description": "Cookies for {username} are expiring soon.\n\nTo fix, [click here](/config/integrations/integration/google_maps#config_entry={entry_id}) then click CONFIGURE and upload new cookies.",
             "title": "Google Maps Cookies Expiring Soon"

--- a/custom_components/google_maps/translations/en.json
+++ b/custom_components/google_maps/translations/en.json
@@ -1,10 +1,11 @@
 {
     "config": {
         "abort": {
-            "reauth_successful": "Re-authentication was successful"
+            "reauth_successful": "Re-authentication was successful.",
+            "reconfigure_successful": "Re-configuration was successful."
         },
         "error": {
-            "already_configured": "Account is already configured",
+            "already_configured": "Account is already configured. Please use a different email address.",
             "invalid_cookies_file": "Invalid cookies file."
         },
         "step": {
@@ -15,16 +16,16 @@
                 "description": "Unlike trackers created for accounts that share their location with {username}, the tracker created for the {username} account holder will be missing some data.\n\nSee {doc} for more information.\n\nShould a tracker be created for the {username} account holder?",
                 "title": "Account Tracker Entity"
             },
+            "check_cookies": {
+                "data": {
+                    "update_cookies": "Update cookies"
+                },
+                "description": "Update cookies for {username}?\n\nExpiration: {expiration}",
+                "title": "Cookies File"
+            },
             "chrome": {
                 "description": "{procedure}",
                 "title": "Get Cookies Using Google Chrome"
-            },
-            "cookies": {
-                "data": {
-                    "use_existing_cookies": "Use existing cookies file"
-                },
-                "description": "Use existing cookies file for {username}?\n\nFound with expiraton of {expiration}:\n\n{cookies_file}",
-                "title": "Use Existing Cookies File"
             },
             "cookies_upload": {
                 "data": {
@@ -40,6 +41,13 @@
             "firefox": {
                 "description": "{procedure}",
                 "title": "Get Cookies Using Mozilla Firefox"
+            },
+            "get_cookies": {
+                "data": {
+                    "use_existing_cookies": "Use existing cookies file"
+                },
+                "description": "Use existing cookies file for {username}?\n\nFound with expiraton of {expiration}:\n\n{cookies_file}",
+                "title": "Use Existing Cookies File"
             },
             "get_cookies_procedure_menu": {
                 "description": "Choose browser type for detailed instructions on how to get a cookies file.",
@@ -72,29 +80,28 @@
                 "description": "Expiration: {expiration}.",
                 "menu_options": {
                     "account_entity": "Continue with cookies",
-                    "get_cookies_procedure_menu": "Upload a different cookies file",
-                    "reauth_done": "Use cookies"
+                    "done": "Use cookies",
+                    "get_cookies_procedure_menu": "Upload a different cookies file"
                 },
                 "title": "Uploaded Cookies"
             },
             "username": {
                 "data": {
-                    "username": "Username"
+                    "username": "Email address"
                 },
                 "description": "The email address for the Google account to be used for retrieving shared location.",
-                "title": "Google Maps Account Username"
+                "title": "Google Maps Account"
             }
         }
     },
     "entity": {
         "binary_sensor": {
             "online": {
-                "name": "Google Maps {title} online"
+                "name": "online"
             }
         },
         "device_tracker": {
             "tracker": {
-                "name": "Google Maps {full_name}",
                 "state_attributes": {
                     "address": {
                         "name": "Address"
@@ -114,8 +121,8 @@
     },
     "issues": {
         "duplicate_usernames": {
-            "description": "{usernames} used in multiple integration entries which is no longer allowed.\n\nTo fix, [click here](/config/integrations/integration/google_maps), remove all but one integration entry for each username, then restart Home Assistant.",
-            "title": "Duplicate Usernames"
+            "description": "{usernames} used in multiple integration entries which is no longer allowed.\n\nTo fix, [click here](/config/integrations/integration/google_maps), remove all but one integration entry for each email address, then restart Home Assistant.",
+            "title": "Duplicate Email Addresses"
         },
         "expiring_soon": {
             "description": "Cookies for {username} are expiring soon.\n\nTo fix, [click here](/config/integrations/integration/google_maps#config_entry={entry_id}) then click CONFIGURE and upload new cookies.",
@@ -138,7 +145,7 @@
                 "description": "{procedure}",
                 "title": "Get Cookies Using Google Chrome"
             },
-            "cookies": {
+            "get_cookies": {
                 "data": {
                     "use_existing_cookies": "Use existing cookies file"
                 },

--- a/custom_components/google_maps/translations/en.json
+++ b/custom_components/google_maps/translations/en.json
@@ -130,9 +130,6 @@
         }
     },
     "options": {
-        "error": {
-            "invalid_cookies_file": "Invalid cookies file."
-        },
         "step": {
             "account_entity": {
                 "data": {
@@ -141,49 +138,6 @@
                 "description": "Unlike trackers created for accounts that share their location with {username}, the tracker created for the {username} account holder will be missing some data.\n\nSee {doc} for more information.\n\nShould a tracker be created for the {username} account holder?",
                 "title": "Account Tracker Entity"
             },
-            "chrome": {
-                "description": "{procedure}",
-                "title": "Get Cookies Using Google Chrome"
-            },
-            "get_cookies": {
-                "data": {
-                    "use_existing_cookies": "Use existing cookies file"
-                },
-                "description": "Use existing cookies file for {username}?\n\nFound with expiraton of {expiration}:\n\n{cookies_file}",
-                "title": "Use Existing Cookies File"
-            },
-            "cookies_upload": {
-                "data": {
-                    "cookies": "Cookies file"
-                },
-                "description": "Upload cookies file for {username}.",
-                "title": "Upload Cookies File"
-            },
-            "edge": {
-                "description": "{procedure}",
-                "title": "Get Cookies Using Microsoft Edge"
-            },
-            "firefox": {
-                "description": "{procedure}",
-                "title": "Get Cookies Using Mozilla Firefox"
-            },
-            "get_cookies_procedure_menu": {
-                "description": "Choose browser type for detailed instructions on how to get a cookies file.",
-                "menu_options": {
-                    "chrome": "Google Chrome",
-                    "cookies_upload": "Continue straight to uploading a file",
-                    "edge": "Microsoft Edge",
-                    "firefox": "Mozilla Firefox"
-                },
-                "title": "Get a Cookies File"
-            },
-            "init": {
-                "data": {
-                    "update_cookies": "Update cookies"
-                },
-                "description": "Update cookies for {username}?\n\nExpiration: {expiration}",
-                "title": "Cookies File"
-            },
             "max_gps_accuracy": {
                 "data": {
                     "max_gps_accuracy": "Maximum GPS accuracy (meters)"
@@ -191,23 +145,11 @@
                 "description": "Location updates with accuracy above this limit will be ignored.",
                 "title": "GPS Accuracy Limit"
             },
-            "old_cookies_invalid": {
-                "description": "Existing cookies file for {username} found but it is invalid:\n\n{cookies_file}",
-                "title": "Invalid Existing Cookies File"
-            },
             "update_period": {
                 "data": {
                     "scan_interval": "Update period"
                 },
                 "title": "Update Period"
-            },
-            "uploaded_cookie_menu": {
-                "description": "Expiration: {expiration}.",
-                "menu_options": {
-                    "account_entity": "Continue with cookies",
-                    "get_cookies_procedure_menu": "Upload a different cookies file"
-                },
-                "title": "Uploaded Cookies"
             }
         }
     }

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Google Maps",
-  "homeassistant": "2024.8.3"
+  "homeassistant": "2024.12.0"
 }


### PR DESCRIPTION
- [x] Drop support for HA versions before 2024.12.0.
- [x] Do not allow multiple config entries with the same username.
  - [x] Create repair issue if multiple config entries use the same username.
  - [x] Do not setup integration if multiple config entries use the same username.
  - [x] Do not allow creating a new config entry with a username that has already been used.
- [x] Fix bug in async_remove_entry when deleting cookies file.
- [x] Delete previous cookies file if user uploads a new one.
- [x] Create service for online binary sensor.
- [x] Use "entity name" with translations for binary_sensor entities (i.e., use service name + entity name).
- [x] Use "entity name" without translations for device_tracker entities (i.e., use device name.)
- [x] Remove device_tracker entities when data is no longer available, after a grace period, in case data was only missing temporarily.
- [x] Remove associated device when user removes device_tracker entity from entity registry.
- [x] Only create device_tracker entities when data is available (i.e., not just from entity registry entries.)
- [x] Bump config version to 3.
  - [x] Move username from data to entry's unique ID.
- [x] Add reconfigure flow & make all config flows start with username.
- [x] Bump config version to 4.
  - [x] Move cookies_file from options to data.
  - [x] Remove cookies file from options flow.
- [x] Merge config version 4 back into 3.
- [x] Close requests session object in executor.
- [x] Save & restore only location specific data.
- [x] Don't use `_friendly_name_internal` removed in 2026.2. Fixes #49.
- [x] Initialize `GMLocSharing` in executor. Fixes #50.