### PR TITLE
Support dynamic scan interval via entity (e.g. input_number) #51

### DIFF
--- a/custom_components/google_maps/config_flow.py
+++ b/custom_components/google_maps/config_flow.py
@@ -30,6 +30,8 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import (
     BooleanSelector,
     DurationSelector,
+    EntitySelector,
+    EntitySelectorConfig,
     FileSelector,
     FileSelectorConfig,
     NumberSelector,
@@ -46,6 +48,7 @@ from .const import (
     CONF_COOKIES_FILE,
     CONF_CREATE_ACCT_ENTITY,
     CONF_MAX_GPS_ACCURACY,
+    CONF_SCAN_INTERVAL_ENTITY,
     DEF_SCAN_INTERVAL_SEC,
     DOMAIN,
 )
@@ -139,16 +142,28 @@ class GoogleMapsFlow(ConfigEntryBaseFlow):
             self._options[CONF_SCAN_INTERVAL] = int(
                 cv.time_period_dict(user_input[CONF_SCAN_INTERVAL]).total_seconds()
             )
+            self._options[CONF_SCAN_INTERVAL_ENTITY] = user_input.get(
+                CONF_SCAN_INTERVAL_ENTITY
+            )
             return await self.async_step_done()
 
-        data_schema = vol.Schema({vol.Required(CONF_SCAN_INTERVAL): DurationSelector()})
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_SCAN_INTERVAL): DurationSelector(),
+                vol.Optional(CONF_SCAN_INTERVAL_ENTITY): EntitySelector(
+                    EntitySelectorConfig(domain=["input_number", "number"])
+                ),
+            }
+        )
         default = self._options.get(CONF_SCAN_INTERVAL, DEF_SCAN_INTERVAL_SEC)
         def_m, def_s = divmod(default, 60)
         def_h, def_m = divmod(def_m, 60)
-        data_schema = self.add_suggested_values_to_schema(
-            data_schema,
-            {CONF_SCAN_INTERVAL: {"hours": def_h, "minutes": def_m, "seconds": def_s}},
-        )
+        suggested: dict[str, Any] = {
+            CONF_SCAN_INTERVAL: {"hours": def_h, "minutes": def_m, "seconds": def_s}
+        }
+        if existing_entity := self._options.get(CONF_SCAN_INTERVAL_ENTITY):
+            suggested[CONF_SCAN_INTERVAL_ENTITY] = existing_entity
+        data_schema = self.add_suggested_values_to_schema(data_schema, suggested)
         return self.async_show_form(step_id="update_period", data_schema=data_schema)
 
     @abstractmethod

--- a/custom_components/google_maps/const.py
+++ b/custom_components/google_maps/const.py
@@ -20,5 +20,6 @@ ATTR_NICKNAME = "nickname"
 CONF_COOKIES_FILE = "cookies_file"
 CONF_CREATE_ACCT_ENTITY = "create_acct_entity"
 CONF_MAX_GPS_ACCURACY = "max_gps_accuracy"
+CONF_SCAN_INTERVAL_ENTITY = "scan_interval_entity"
 
 DT_NO_RECORD_ATTRS = frozenset({ATTR_ADDRESS, ATTR_ENTITY_PICTURE, ATTR_NICKNAME})

--- a/custom_components/google_maps/coordinator.py
+++ b/custom_components/google_maps/coordinator.py
@@ -10,17 +10,26 @@ import logging
 from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_SCAN_INTERVAL, EVENT_HOMEASSISTANT_FINAL_WRITE
+from homeassistant.const import (
+    CONF_SCAN_INTERVAL,
+    EVENT_HOMEASSISTANT_FINAL_WRITE,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.helpers.event import (
+    async_track_point_in_utc_time,
+    async_track_state_change_event,
+)
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_COOKIES_FILE,
     CONF_CREATE_ACCT_ENTITY,
+    CONF_SCAN_INTERVAL_ENTITY,
     COOKIE_WARNING_PERIOD,
     DOMAIN,
 )
@@ -73,6 +82,45 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
             always_update=False,
         )
 
+        if interval_entity := entry.options.get(CONF_SCAN_INTERVAL_ENTITY):
+            entry.async_on_unload(
+                async_track_state_change_event(
+                    hass, [interval_entity], self._handle_interval_entity_change
+                )
+            )
+
+    @callback
+    def _apply_update_interval(self, interval: timedelta) -> None:
+        """Apply a new update interval and reschedule the next refresh."""
+        if hasattr(self, "async_set_update_interval"):
+            self.async_set_update_interval(interval)
+        else:
+            self.update_interval = interval
+            if self._unsub_refresh:
+                self._unsub_refresh()
+                self._unsub_refresh = None
+            self._schedule_refresh()
+
+    @callback
+    def _handle_interval_entity_change(self, event: Event) -> None:
+        """Handle state change of the dynamic scan interval entity."""
+        new_state = event.data.get("new_state")
+        if new_state is None or new_state.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+            return
+        try:
+            new_seconds = float(new_state.state)
+        except (ValueError, TypeError):
+            return
+        if new_seconds <= 0:
+            return
+        self._apply_update_interval(timedelta(seconds=new_seconds))
+        _LOGGER.debug(
+            "Update interval changed to %s seconds via %s",
+            new_seconds,
+            event.data.get("entity_id"),
+        )
+        self.hass.async_create_task(self.async_refresh())
+
     async def async_shutdown(self) -> None:
         """Cancel listeners, save cookies & close API."""
         await super().async_shutdown()
@@ -111,6 +159,19 @@ class GMDataUpdateCoordinator(DataUpdateCoordinator[GMData]):
             except (InvalidCookiesFile, InvalidCookies) as err:
                 raise ConfigEntryAuthFailed(f"{err.__class__.__name__}: {err}") from err
             self._cookies_file_synced()
+
+        # Apply current state of the dynamic interval entity if already available.
+        if (
+            (interval_entity := self.config_entry.options.get(CONF_SCAN_INTERVAL_ENTITY))
+            and (state := self.hass.states.get(interval_entity))
+            and state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
+        ):
+            try:
+                new_seconds = float(state.state)
+                if new_seconds > 0:
+                    self._apply_update_interval(timedelta(seconds=new_seconds))
+            except (ValueError, TypeError):
+                pass
 
     async def _async_update_data(self) -> GMData:
         """Fetch the latest data from the source.

--- a/custom_components/google_maps/translations/en.json
+++ b/custom_components/google_maps/translations/en.json
@@ -72,7 +72,12 @@
             },
             "update_period": {
                 "data": {
-                    "scan_interval": "Update period"
+                    "scan_interval": "Update period (fallback)",
+                    "scan_interval_entity": "Dynamic scan interval entity (optional)"
+                },
+                "data_description": {
+                    "scan_interval": "Used when no dynamic entity is set, or when the entity is unavailable.",
+                    "scan_interval_entity": "When set, this input_number or number entity controls the scan interval at runtime. Changes apply immediately without restarting the integration."
                 },
                 "title": "Update Period"
             },
@@ -147,7 +152,12 @@
             },
             "update_period": {
                 "data": {
-                    "scan_interval": "Update period"
+                    "scan_interval": "Update period (fallback)",
+                    "scan_interval_entity": "Dynamic scan interval entity (optional)"
+                },
+                "data_description": {
+                    "scan_interval": "Used when no dynamic entity is set, or when the entity is unavailable.",
+                    "scan_interval_entity": "When set, this input_number or number entity controls the scan interval at runtime. Changes apply immediately without restarting the integration."
                 },
                 "title": "Update Period"
             }


### PR DESCRIPTION
https://github.com/pnbruckner/ha-google-maps/issues/51

This PR adds optional support for a dynamic scan interval controlled by a Home Assistant entity (e.g. input_number or number), allowing the Google Maps integration polling frequency to change at runtime without requiring a restart or reconfiguration.

A static fallback interval is still fully supported.

**Motivation / Use case**

The current `scan_interval` is fixed at configuration time. In mobile tracking scenarios this is suboptimal.

My use case:

When far from home - slow polling (e.g. 5–15 min)
When approaching home - fast polling (e.g. 30–60 sec)
When at home / on Wi-Fi - slow again

This behavior is driven by Home Assistant logic (e.g. proximity, device tracker, or Wi-Fi state).

To support this, I use a helper:
```yaml
input_number:
  google_maps_scan_interval:
    name: Google Maps Scan Interval
    initial: 300
    min: 30
    max: 1800
    step: 30
    unit_of_measurement: seconds
```
**Proposed feature**

Add an optional config entry:

`scan_interval` - fallback static interval (existing behavior preserved)
`scan_interval_entity` - optional entity controlling interval dynamically

When provided:

Integration listens for state changes
Interval is updated immediately without restart
Invalid/unavailable states are ignored safely
Falls back to static interval if entity is unavailable

**Implementation details**

Changes included:

Config Flow
  - Added EntitySelector for scan_interval_entity
  - Stored in config entry options
  - Added translations + suggested values support

Coordinator
  - Subscribes to state changes via:
     - async_track_state_change_event
  - Applies updates dynamically using:
     - async_set_update_interval() when available
     - fallback to manual reschedule logic
  - Applies initial entity value on startup
  - Safely handles:
     - unknown
     - unavailable
     - invalid numeric values

Safety considerations
  - Only accepts positive numeric values
  - No restart required
  - No breaking change for existing configs


**Behavior**

Priority logic:

  - If `scan_interval_entity` exists and is valid - use it
  - Otherwise - use static `scan_interval`

Updates are applied:

  - immediately on state change
  - and once on integration startup


**UI / UX improvement**

Config UI now includes:

  - Update period (fallback)
  - Optional dynamic interval entity selector

This makes the feature discoverable without requiring YAML.

-----

I’ve tested this locally with proximity-based automation and it works reliably without excessive API calls or scheduler instability.