### PR TITLE
Add per-person sensor entities for address, last seen, battery level & GPS accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,21 @@ See the description above about "Refined Filtering of Data Updates" for more inf
 
 This option controls the time between requests for updates.
 
+## Sensor Entities
+
+In addition to the `device_tracker` entity created for each person, a handful of `sensor` entities are also created for each, grouped on the same device. These simply expose data that was previously only available as `device_tracker` attributes, so it can be used directly (e.g., in dashboard cards, history graphs, or automations) without needing a template helper.
+
+| Sensor | Enabled by default | Category |
+| --- | --- | --- |
+| Address | Yes | — |
+| Last seen | Yes | Diagnostic |
+| Battery level | Yes | Diagnostic |
+| GPS accuracy | No | Diagnostic |
+
+GPS accuracy is disabled by default since it's mainly useful for troubleshooting; enable it from Settings -> Devices & services -> Entities if you want it.
+
+The Address, Last seen & GPS accuracy sensors apply the same "Refined Filtering of Data Updates" (see above) as the `device_tracker` entity itself, so they stay in agreement with the position it shows. One difference: this filtering "memory" does not survive a Home Assistant restart (the `device_tracker` entity's does), so right after a restart these three sensors will briefly show `Unknown` until the next update is received, rather than the last known value.
+
 ## Missing Data for Account Tracker
 
 The ["account holder" tracker entity](#account-tracker-entity), if created,
@@ -198,6 +213,8 @@ and the following attributes will be missing or invalid:
 `battery_charging`, `battery_level`, `entity_picture` & `nickname`
 
 All other attributes, including those related to location, will be present and valid.
+
+For the same reason, the account holder's [Battery level sensor](#sensor-entities) will always be `Unknown`.
 
 ## Account Strategies
 

--- a/custom_components/google_maps/__init__.py
+++ b/custom_components/google_maps/__init__.py
@@ -31,7 +31,7 @@ from .helpers import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-_PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER]
+_PLATFORMS = [Platform.BINARY_SENSOR, Platform.DEVICE_TRACKER, Platform.SENSOR]
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 

--- a/custom_components/google_maps/device_tracker.py
+++ b/custom_components/google_maps/device_tracker.py
@@ -33,7 +33,14 @@ from .const import (
     MISSING_DATA_GRACE_PERIOD,
 )
 from .coordinator import GMConfigEntry, GMDataUpdateCoordinator
-from .helpers import CFG_UNIQUE_IDS, ConfigID, LocationData, UniqueID, dev_ids
+from .helpers import (
+    CFG_UNIQUE_IDS,
+    ConfigID,
+    LocationData,
+    UniqueID,
+    dev_ids,
+    resolve_loc_update,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -373,41 +380,13 @@ class GoogleMapsDeviceTracker(
 
     def _update_loc(self, loc: LocationData) -> None:
         """Update location data if possible."""
-        last_seen = loc.last_seen
-        # Don't use "new" loc data if it really isn't new.
-        if prev_seen := self._loc and self._loc.last_seen:
-            if last_seen < prev_seen:
-                self._log_ignore_reason(
-                    "timestamp went backwards: "
-                    f"{dt_util.as_local(last_seen)} < {dt_util.as_local(prev_seen)}"
-                )
-                return
-            if last_seen == prev_seen:
-                return
-
-        last_gps_accuracy = loc.gps_accuracy
-        if prev_gps_accuracy := self._loc and self._loc.gps_accuracy:
-            # We have previous loc data.
-            if prev_gps_accuracy <= self._max_gps_accuracy:
-                # Previous loc data is "accurate."
-                # Don't use new loc data if it is inaccurate.
-                if last_gps_accuracy > self._max_gps_accuracy:
-                    self._log_ignore_reason(
-                        f"GPS accuracy ({last_gps_accuracy}) is greater than limit "
-                        f"({self._max_gps_accuracy})"
-                    )
-                    return
-            # Previous loc data is inaccurate.
-            # Don't use new data if it is less accurate.
-            elif last_gps_accuracy > prev_gps_accuracy:
-                self._log_ignore_reason(
-                    f"GPS accuracy ({last_gps_accuracy}) is greater than limit "
-                    f"({self._max_gps_accuracy}) and worse than previous "
-                    f"({prev_gps_accuracy})"
-                )
-                return
-
-        self._loc = loc
+        new_loc, ignore_reason = resolve_loc_update(
+            self._loc, loc, self._max_gps_accuracy
+        )
+        if ignore_reason:
+            self._log_ignore_reason(ignore_reason)
+            return
+        self._loc = new_loc
 
     def _log_ignore_reason(self, reason: str) -> None:
         """Log reason for ignoring location data."""

--- a/custom_components/google_maps/helpers.py
+++ b/custom_components/google_maps/helpers.py
@@ -105,6 +105,40 @@ class LocationData(ExtraStoredData):
         )
 
 
+def resolve_loc_update(
+    prev: LocationData | None, new: LocationData, max_gps_accuracy: int
+) -> tuple[LocationData, str | None]:
+    """Decide if new location data should replace prev.
+
+    This is the integration's "refined filtering" rule (see README), shared by every
+    entity that tracks a person's location so they all stay in agreement.
+
+    Returns the location data to use (new, or prev if new should be ignored) and, if
+    new was ignored for a reason worth logging, that reason (else None).
+    """
+    if prev_seen := prev and prev.last_seen:
+        if new.last_seen < prev_seen:
+            return prev, (
+                "timestamp went backwards: "
+                f"{dt_util.as_local(new.last_seen)} < {dt_util.as_local(prev_seen)}"
+            )
+        if new.last_seen == prev_seen:
+            return prev, None
+    if prev_gps_accuracy := prev and prev.gps_accuracy:
+        if prev_gps_accuracy <= max_gps_accuracy:
+            if new.gps_accuracy > max_gps_accuracy:
+                return prev, (
+                    f"GPS accuracy ({new.gps_accuracy}) is greater than limit "
+                    f"({max_gps_accuracy})"
+                )
+        elif new.gps_accuracy > prev_gps_accuracy:
+            return prev, (
+                f"GPS accuracy ({new.gps_accuracy}) is greater than limit "
+                f"({max_gps_accuracy}) and worse than previous ({prev_gps_accuracy})"
+            )
+    return new, None
+
+
 @dataclass(frozen=True)
 class MiscData:
     """Miscellaneous data."""

--- a/custom_components/google_maps/sensor.py
+++ b/custom_components/google_maps/sensor.py
@@ -1,0 +1,249 @@
+"""Google Maps sensors."""
+from __future__ import annotations
+
+import asyncio
+from copy import copy
+from datetime import datetime
+from functools import partial
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfLength
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import ATTRIBUTION, CONF_MAX_GPS_ACCURACY, MISSING_DATA_GRACE_PERIOD
+from .coordinator import GMConfigEntry, GMDataUpdateCoordinator
+from .helpers import (
+    CFG_UNIQUE_IDS,
+    ConfigID,
+    LocationData,
+    UniqueID,
+    dev_ids,
+    resolve_loc_update,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: GMConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the sensor platform."""
+    cid = ConfigID(entry.entry_id)
+    coordinator = entry.runtime_data.coordinator
+    max_gps_accuracy = entry.options[CONF_MAX_GPS_ACCURACY]
+    unique_ids = hass.data[CFG_UNIQUE_IDS]
+
+    lock = asyncio.Lock()
+    entities: dict[UniqueID, list[GoogleMapsSensor]] = {}
+    # Value is the unsub callback while the removal timer is pending, or None once it
+    # has fired. The key stays in this dict (matching device_tracker.py's approach)
+    # until the person's data becomes available again.
+    missing: dict[UniqueID, CALLBACK_TYPE | None] = {}
+
+    def schedule_entity_removal(uid: UniqueID) -> None:
+        """Schedule entities to be removed."""
+        assert uid not in missing
+        missing[uid] = async_call_later(
+            hass, MISSING_DATA_GRACE_PERIOD, partial(remove_entities, uid)
+        )
+
+    def unschedule_entity_removal(uid: UniqueID) -> None:
+        """Unschedule removal of entities."""
+        if unsub := missing.pop(uid):
+            unsub()
+
+    async def remove_entities(uid: UniqueID, _: datetime) -> None:
+        """Remove entities whose person data has been missing too long."""
+        async with lock:
+            missing[uid] = None
+            removed = entities.pop(uid)
+            await asyncio.gather(*(entity.async_remove() for entity in removed))
+
+    async def update_entities() -> None:
+        """Update entities for people."""
+        async with lock:
+            uids = frozenset(coordinator.data)
+
+            for uid in missing.keys() & uids:
+                unschedule_entity_removal(uid)
+
+            for uid in entities.keys() - uids - missing.keys():
+                schedule_entity_removal(uid)
+
+            if create_uids := unique_ids.take(cid, uids) - entities.keys():
+                new_entities: list[GoogleMapsSensor] = []
+                for uid in create_uids:
+                    person_entities: list[GoogleMapsSensor] = [
+                        GoogleMapsAddressSensor(coordinator, uid, max_gps_accuracy),
+                        GoogleMapsLastSeenSensor(coordinator, uid, max_gps_accuracy),
+                        GoogleMapsGpsAccuracySensor(
+                            coordinator, uid, max_gps_accuracy
+                        ),
+                        GoogleMapsBatteryLevelSensor(coordinator, uid),
+                    ]
+                    entities[uid] = person_entities
+                    new_entities.extend(person_entities)
+                async_add_entities(new_entities)
+
+    @callback
+    def update_entities_cb() -> None:
+        """Update entities for people."""
+        entry.async_create_background_task(
+            hass, update_entities(), f"Update sensors for {entry.title}"
+        )
+
+    await update_entities()
+    entry.async_on_unload(coordinator.async_add_listener(update_entities_cb))
+
+
+class GoogleMapsSensor(CoordinatorEntity[GMDataUpdateCoordinator], SensorEntity):
+    """Base class for Google Maps per-person sensors."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+
+    def __init__(
+        self, coordinator: GMDataUpdateCoordinator, uid: UniqueID, key: str
+    ) -> None:
+        """Initialize sensor."""
+        super().__init__(coordinator)
+        self._uid = uid
+        self._attr_unique_id = f"{uid}_{key}"
+        self._attr_translation_key = key
+        # Deliberately minimal: the device itself (name, etc.) is established by the
+        # GoogleMapsDeviceTracker entity for this uid; this just attaches to it.
+        self._attr_device_info = dr.DeviceInfo(identifiers=dev_ids(uid))
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return True
+
+
+class GoogleMapsLocationSensor(GoogleMapsSensor):
+    """Base class for sensors driven by (filtered) location data.
+
+    Applies the same "refined filtering" rule as GoogleMapsDeviceTracker so values
+    shown here stay consistent with the tracker's own position. Note that, unlike the
+    tracker, this filtering memory does not survive a Home Assistant restart, so the
+    first update after a restart is always accepted regardless of accuracy.
+    """
+
+    _loc: LocationData | None = None
+
+    def __init__(
+        self,
+        coordinator: GMDataUpdateCoordinator,
+        uid: UniqueID,
+        key: str,
+        max_gps_accuracy: int,
+    ) -> None:
+        """Initialize sensor."""
+        super().__init__(coordinator, uid, key)
+        self._max_gps_accuracy = max_gps_accuracy
+        self._update_loc(copy(coordinator.data[uid].loc))
+
+    def _update_loc(self, loc: LocationData) -> None:
+        """Update location data if it passes the same filter as the tracker."""
+        self._loc, _ = resolve_loc_update(self._loc, loc, self._max_gps_accuracy)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if not (data := self.coordinator.data.get(self._uid)):
+            # Data not available. Keep current data for now.
+            return
+        self._update_loc(copy(data.loc))
+        super()._handle_coordinator_update()
+
+
+class GoogleMapsAddressSensor(GoogleMapsLocationSensor):
+    """Google Maps address sensor."""
+
+    _attr_icon = "mdi:map-marker"
+
+    def __init__(
+        self, coordinator: GMDataUpdateCoordinator, uid: UniqueID, max_gps_accuracy: int
+    ) -> None:
+        """Initialize sensor."""
+        super().__init__(coordinator, uid, "address", max_gps_accuracy)
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the address of the device."""
+        return self._loc.address if self._loc else None
+
+
+class GoogleMapsLastSeenSensor(GoogleMapsLocationSensor):
+    """Google Maps last seen sensor."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(
+        self, coordinator: GMDataUpdateCoordinator, uid: UniqueID, max_gps_accuracy: int
+    ) -> None:
+        """Initialize sensor."""
+        super().__init__(coordinator, uid, "last_seen", max_gps_accuracy)
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return when the device was last seen."""
+        return self._loc.last_seen if self._loc else None
+
+
+class GoogleMapsGpsAccuracySensor(GoogleMapsLocationSensor):
+    """Google Maps GPS accuracy sensor."""
+
+    _attr_device_class = SensorDeviceClass.DISTANCE
+    _attr_native_unit_of_measurement = UnitOfLength.METERS
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self, coordinator: GMDataUpdateCoordinator, uid: UniqueID, max_gps_accuracy: int
+    ) -> None:
+        """Initialize sensor."""
+        super().__init__(coordinator, uid, "gps_accuracy", max_gps_accuracy)
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the GPS accuracy of the device's location."""
+        return self._loc.gps_accuracy if self._loc else None
+
+
+class GoogleMapsBatteryLevelSensor(GoogleMapsSensor):
+    """Google Maps battery level sensor."""
+
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_native_unit_of_measurement = PERCENTAGE
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    _battery_level: int | None = None
+
+    def __init__(self, coordinator: GMDataUpdateCoordinator, uid: UniqueID) -> None:
+        """Initialize sensor."""
+        super().__init__(coordinator, uid, "battery_level")
+        self._battery_level = coordinator.data[uid].misc.battery_level
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the battery level of the device."""
+        return self._battery_level
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if not (data := self.coordinator.data.get(self._uid)):
+            # Data not available. Keep current data for now.
+            return
+        self._battery_level = data.misc.battery_level
+        super()._handle_coordinator_update()

--- a/custom_components/google_maps/translations/en.json
+++ b/custom_components/google_maps/translations/en.json
@@ -117,6 +117,20 @@
                     }
                 }
             }
+        },
+        "sensor": {
+            "address": {
+                "name": "Address"
+            },
+            "battery_level": {
+                "name": "Battery level"
+            },
+            "gps_accuracy": {
+                "name": "GPS accuracy"
+            },
+            "last_seen": {
+                "name": "Last seen"
+            }
         }
     },
     "issues": {


### PR DESCRIPTION
## Summary
- Adds a new `sensor` platform with four per-person sensors grouped on the same device as the existing `device_tracker` entity: `address`, `last_seen`, `battery_level`, and `gps_accuracy`.
- Motivation: these values were previously only reachable as `device_tracker` attributes (e.g. `state_attr('device_tracker.google_maps_x', 'address')`), which required a template helper to use directly in dashboards/history/automations. Promoting them to real sensor entities gives them history graphing and direct usability without a template.
- `address`, `last_seen` & `battery_level` are enabled by default; `gps_accuracy` is disabled by default (diagnostic-only, mainly useful for troubleshooting).
- Extracted the existing "refined filtering" accuracy/staleness decision logic out of `GoogleMapsDeviceTracker._update_loc` into a shared `resolve_loc_update()` helper in `helpers.py`, reused by both the tracker and the new location-derived sensors so they can't diverge. `device_tracker.py`'s behavior is unchanged (pure refactor — same conditions, same log messages).
- Updated `README.md` with a new "Sensor Entities" section, and a note on the account tracker's `Battery level` sensor always being `Unknown` for the same reason its other attributes are already documented as missing.
- Updated `translations/en.json` with entity names for the new sensors.

No changes to config entry data/options/version, cookie handling, or authentication — purely additive entities sourced from data the coordinator already fetches.

## Test plan
- [x] Deployed to a live Home Assistant instance (HAOS) and restarted; verified no errors in the log for `google_maps`.
- [x] Confirmed all 4 sensors are created per person with correct values (address, last-seen timestamp, battery %) and correctly grouped under the existing per-person device.
- [x] Confirmed `gps_accuracy` is created but disabled by default (`disabled_by: "integration"` in the entity registry).
- [x] Confirmed the account-holder tracker's `battery_level` sensor correctly shows `Unknown`.
- [x] Confirmed existing `device_tracker` entities and their attributes/state are unaffected.